### PR TITLE
Removed erroneous unlock/lock

### DIFF
--- a/pkg/storage/waitingcache/waiting_cache.go
+++ b/pkg/storage/waitingcache/waiting_cache.go
@@ -89,7 +89,6 @@ func (i *WaitingCache) markAvailableRemoteBlock(b uint) {
 	if !avail {
 		i.remote.available.SetBit(int(b))
 	}
-	i.lockersLock.Unlock()
 
 	// If we have waiters for it, we can go ahead and unlock to allow them to read it.
 	if !avail && ok {
@@ -97,7 +96,6 @@ func (i *WaitingCache) markAvailableRemoteBlock(b uint) {
 	}
 
 	// Now we can get rid of the lock on this block...
-	i.lockersLock.Lock()
 	delete(i.lockers, b)
 	i.lockersLock.Unlock()
 }


### PR DESCRIPTION
which caused possible race condition failure with unlock() called by multiple goroutines.

The original code had a quick unlock() and then lock() while it does a block level unlock, to allow readers to read the now available block.
However, this meant that multiple goroutines could call the blocks Unlock() causing a panic. Only ONE should, which is why the main lock should remain locked while the block lock is unlocked.