### PR TITLE
Fixed issue in file_storage_sparse

### DIFF
--- a/pkg/storage/modules/copy_on_write_test.go
+++ b/pkg/storage/modules/copy_on_write_test.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"crypto/rand"
+	"os"
 	"testing"
 
 	"github.com/loopholelabs/silo/pkg/storage"
@@ -157,8 +158,12 @@ func TestCopyOnWriteCRCIssue(t *testing.T) {
 	size := 16 * 1024
 	blockSize := 64 * 1024
 
-	fstore, err := sources.NewFileStorageSparseCreate("./test.sparse", uint64(size), blockSize)
+	fstore, err := sources.NewFileStorageSparseCreate("test_data_sparse", uint64(size), blockSize)
 	assert.NoError(t, err)
+
+	t.Cleanup(func() {
+		os.Remove("test_data_sparse")
+	})
 
 	//	fstore := sources.NewMemoryStorage(size)
 

--- a/pkg/storage/modules/copy_on_write_test.go
+++ b/pkg/storage/modules/copy_on_write_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"testing"
 
+	"github.com/loopholelabs/silo/pkg/storage"
 	"github.com/loopholelabs/silo/pkg/storage/sources"
 	"github.com/stretchr/testify/assert"
 )
@@ -148,4 +149,71 @@ func TestCopyOnWriteReadOverrunNonMultiple(t *testing.T) {
 	assert.Equal(t, 50, n)
 
 	assert.Equal(t, onlydata[size-50:], buff2[:50])
+}
+
+func TestCopyOnWriteCRCIssue(t *testing.T) {
+
+	// Create a new block storage, backed by memory storage
+	size := 16 * 1024
+	blockSize := 64 * 1024
+
+	fstore, err := sources.NewFileStorageSparseCreate("./test.sparse", uint64(size), blockSize)
+	assert.NoError(t, err)
+
+	//	fstore := sources.NewMemoryStorage(size)
+
+	rosource := sources.NewMemoryStorage(size)
+
+	fstore_log := NewLogger(fstore, "fstore")
+
+	cow := NewCopyOnWrite(rosource, fstore_log, blockSize)
+
+	reference := sources.NewMemoryStorage(size)
+
+	// Fill it with random stuff
+	data := make([]byte, size)
+	_, err = rand.Read(data)
+	assert.NoError(t, err)
+	_, err = rosource.WriteAt(data, 0)
+	assert.NoError(t, err)
+	_, err = reference.WriteAt(data, 0)
+	assert.NoError(t, err)
+
+	// Now do some WriteAt() calls, and then a big ReadAt() and make sure they match
+
+	doWrite := func(offset int64) {
+		buffer := make([]byte, 4096)
+		_, err := rand.Read(buffer)
+		assert.NoError(t, err)
+
+		n, err := cow.WriteAt(buffer, offset)
+		assert.NoError(t, err)
+		assert.Equal(t, n, 4096)
+
+		n, err = reference.WriteAt(buffer, offset)
+		assert.NoError(t, err)
+		assert.Equal(t, n, 4096)
+	}
+
+	doWrite(8192)
+	doWrite(0)
+	doWrite(4096)
+
+	// Now check they are equal
+
+	eq, err := storage.Equals(reference, fstore, blockSize)
+	assert.NoError(t, err)
+	assert.True(t, eq)
+
+	eq, err = storage.Equals(reference, cow, blockSize)
+	assert.NoError(t, err)
+	assert.True(t, eq)
+
+	buff_cow := make([]byte, cow.Size())
+	_, err = cow.ReadAt(buff_cow, 0)
+	assert.NoError(t, err)
+
+	buff_ref := make([]byte, reference.Size())
+	_, err = reference.ReadAt(buff_ref, 0)
+	assert.NoError(t, err)
 }

--- a/pkg/storage/modules/copy_on_write_test.go
+++ b/pkg/storage/modules/copy_on_write_test.go
@@ -165,8 +165,6 @@ func TestCopyOnWriteCRCIssue(t *testing.T) {
 		os.Remove("test_data_sparse")
 	})
 
-	//	fstore := sources.NewMemoryStorage(size)
-
 	rosource := sources.NewMemoryStorage(size)
 
 	fstore_log := NewLogger(fstore, "fstore")

--- a/pkg/storage/sources/file_storage_sparse.go
+++ b/pkg/storage/sources/file_storage_sparse.go
@@ -208,10 +208,11 @@ func (i *FileStorageSparse) WriteAt(buffer []byte, offset int64) (int, error) {
 				// Partial write at the end
 				block_buffer := make([]byte, i.block_size)
 				var err error
-				// IF it's the last block partial, we don't need to do a read. It's complete already
-				if block_offset+int64(i.block_size) > int64(i.size) {
-					// We don't need to read the last block here.
-				} else {
+
+				data_len := buffer_end - (block_offset - offset)
+
+				// If the write doesn't extend to the end of the storage size, we need to do a read first.
+				if block_offset+data_len < int64(i.size) {
 					err = i.readBlock(block_buffer, b)
 				}
 				if err != nil {


### PR DESCRIPTION
Fixed issue in file_storage_sparse partial WriteAt on last block not extending to Size().
The bug meant that a read() / merge was not being done. Just a write().
This meant that previous data on the block could be lost and corrupted.