### PR TITLE
Fixed bug from refactor. break inside switch

### DIFF
--- a/pkg/storage/expose/nbd_dispatch.go
+++ b/pkg/storage/expose/nbd_dispatch.go
@@ -143,6 +143,7 @@ func (d *Dispatch) Handle() error {
 
 		// Now go through processing complete packets
 		rp := 0
+	process:
 		for {
 
 			// If the context has been cancelled, quit
@@ -183,7 +184,7 @@ func (d *Dispatch) Handle() error {
 					rp += 28
 					if wp-rp < int(request.Length) {
 						rp -= 28
-						break // We don't have enough data yet... Wait for next read
+						break process // We don't have enough data yet... Wait for next read
 					}
 					d.metricPacketsIn++
 					data := make([]byte, request.Length)


### PR DESCRIPTION
Noticed too late that a break inside if/elseif wasn't adjusted when it was converted to a switch/case.
It's an edge case so doesn't crop up in tests too often.