### PR TITLE
Jamesmoore/arch 166 integrate s3 sync silo into drafter

### DIFF
--- a/pkg/storage/config/silo.go
+++ b/pkg/storage/config/silo.go
@@ -45,6 +45,7 @@ type SyncS3Schema struct {
 	Endpoint  string            `hcl:"endpoint,attr"`
 	Bucket    string            `hcl:"bucket,attr"`
 	Config    *SyncConfigSchema `hcl:"config,block"`
+	AutoStart bool              `hcl:"autostart,attr"`
 }
 
 func parseByteValue(val string) int64 {

--- a/pkg/storage/migrator/migrator_s3_assisted_test.go
+++ b/pkg/storage/migrator/migrator_s3_assisted_test.go
@@ -241,6 +241,10 @@ func TestMigratorS3Assisted(t *testing.T) {
 	assert.Equal(t, false, storage.SendSiloEvent(provSrc, "sync.running", nil)[0].(bool))
 	assert.Equal(t, true, storage.SendSiloEvent(provDest, "sync.running", nil)[0].(bool))
 
+	err = provDest.Close()
+	assert.NoError(t, err)
+	assert.Equal(t, false, storage.SendSiloEvent(provDest, "sync.running", nil)[0].(bool))
+
 }
 
 /**
@@ -391,5 +395,9 @@ func TestMigratorS3AssistedChangeSource(t *testing.T) {
 	// Sync should be running on the dest and NOT on src
 	assert.Equal(t, false, storage.SendSiloEvent(provSrc, "sync.running", nil)[0].(bool))
 	assert.Equal(t, true, storage.SendSiloEvent(provDest, "sync.running", nil)[0].(bool))
+
+	err = provDest.Close()
+	assert.NoError(t, err)
+	assert.Equal(t, false, storage.SendSiloEvent(provDest, "sync.running", nil)[0].(bool))
 
 }

--- a/pkg/storage/protocol/from_protocol.go
+++ b/pkg/storage/protocol/from_protocol.go
@@ -161,6 +161,14 @@ func (fp *FromProtocol) HandleEvent(cb func(*packets.Event)) error {
 			return err
 		}
 
+		if ev.Type == packets.EventCompleted {
+			// Deal with the sync here, and WAIT if needed.
+			storage.SendSiloEvent(fp.prov, "sync.start", storage.SyncStartConfig{
+				AlternateSources: fp.GetAlternateSources(),
+				Destination:      fp.prov,
+			})
+		}
+
 		// Relay the event, wait, and then respond.
 		cb(ev)
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/loopholelabs/silo/pkg/storage/protocol/packets"
 	"github.com/loopholelabs/silo/pkg/storage/util"
 )
 
@@ -52,6 +53,11 @@ var BlockTypeAny = -1
 var BlockTypeStandard = 0
 var BlockTypeDirty = 1
 var BlockTypePriority = 2
+
+type SyncStartConfig struct {
+	AlternateSources []packets.AlternateSource
+	Destination      Provider
+}
 
 /**
  * Check if two storageProviders hold the same data.


### PR DESCRIPTION
This adds the final pieces required for automatic S3 sync

* New config 'autostart' which if set will start S3 sync automatically. For a migration destination this should be false.
* When the storage provider returned by NewDevice is Closed(), it now stops the S3 sync and waits until completed.
* In FromProtocol, when the eventCompleted is received, it will now call the sync.Start, which grabs from S3 and starts sync.

Implementation notes:
* This should now be a pure config integration, with just S3 sync config required for each device.
* To be sure all data is present, the caller should wait for the EventCompleted event and make sure it has been received, since this can now be delayed by local grabbing of S3 data.