### PR TITLE
Fixed issue in waitingcache local write/read, and fixed migrator flakey test

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -170,10 +170,6 @@ func shutdownEverything() {
 }
 
 func setupStorageDevice(conf *config.DeviceSchema) (*storageInfo, error) {
-	blockSize := 1024 * 128
-
-	numBlocks := (int(conf.ByteSize()) + blockSize - 1) / blockSize
-
 	source, ex, err := device.NewDevice(conf)
 	if err != nil {
 		return nil, err
@@ -182,6 +178,15 @@ func setupStorageDevice(conf *config.DeviceSchema) (*storageInfo, error) {
 		fmt.Printf("Device %s exposed as %s\n", conf.Name, ex.Device())
 		srcExposed = append(srcExposed, ex)
 	}
+
+	blockSize := 1024 * 128
+
+	if conf.BlockSize != "" {
+		blockSize = int(conf.ByteBlockSize())
+	}
+
+	numBlocks := (int(conf.ByteSize()) + blockSize - 1) / blockSize
+
 	sourceMetrics := modules.NewMetrics(source)
 	sourceDirtyLocal, sourceDirtyRemote := dirtytracker.NewDirtyTracker(sourceMetrics, blockSize)
 	sourceMonitor := volatilitymonitor.NewVolatilityMonitor(sourceDirtyLocal, blockSize, 10*time.Second)

--- a/pkg/storage/device/device_sync_test.go
+++ b/pkg/storage/device/device_sync_test.go
@@ -114,7 +114,7 @@ func TestDeviceSync(t *testing.T) {
 	metrics := stats[0].(*sources.S3Metrics)
 
 	// Do some asserts on the S3Metrics... It should have written each block at least once by now.
-	assert.GreaterOrEqual(t, numBlocks, int(metrics.BlocksWCount))
+	assert.GreaterOrEqual(t, int(metrics.BlocksWCount), numBlocks)
 
 	assert.Equal(t, false, storage.SendSiloEvent(prov, "sync.running", nil)[0].(bool))
 

--- a/pkg/storage/migrator/sync.go
+++ b/pkg/storage/migrator/sync.go
@@ -158,6 +158,7 @@ func (s *Syncer) Sync(syncAllFirst bool, continuous bool) (*MigrationProgress, e
 		s.blockStatusLock.Lock()
 		if !s.blockStatus[b.Block].Set {
 			s.blockStatus[b.Block].Set = true
+			s.blockStatus[b.Block].CurrentID = id
 			s.blockStatus[b.Block].CurrentHash = hash
 		} else if id > s.blockStatus[b.Block].CurrentID {
 			s.blockStatus[b.Block].CurrentID = id

--- a/pkg/storage/waitingcache/waiting_cache_test.go
+++ b/pkg/storage/waitingcache/waiting_cache_test.go
@@ -182,3 +182,25 @@ func TestWaitingCacheLocalWrites_ARCH61(t *testing.T) {
 	assert.InDelta(t, waitTime, 50, 10)
 
 }
+
+func TestWaitingCacheLocalWriteRead(t *testing.T) {
+
+	// Create a new block storage, backed by memory storage
+	size := 1024 * 1024 * 2
+	mem := sources.NewMemoryStorage(size)
+	metrics := modules.NewMetrics(mem)
+	waitingLocal, _ := NewWaitingCache(metrics, 4096)
+
+	data := make([]byte, 8192)
+	_, err := rand.Read(data)
+	assert.NoError(t, err)
+
+	_, err = waitingLocal.WriteAt(data, 0)
+	assert.NoError(t, err)
+
+	data2 := make([]byte, len(data))
+	_, err = waitingLocal.ReadAt(data2, 0)
+	assert.NoError(t, err)
+
+	assert.Equal(t, data, data2)
+}


### PR DESCRIPTION
BugFix: In WaitingCache, there was a bug when doing a full block local write, a subsequent local read would still wait for a remote block, even though we have the local block. This *could* have resulted in migrations never completing.
BugFix: In test TestMigratorWithReaderWriterWrite it was doing source writes, but not doing a MigrateDirty, which meant that the test sometimes failed with data unequal.