### PR TITLE
arch-209-silo-buffered-packets

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,10 +24,6 @@ linters-settings:
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/loopholelabs/scale
   govet:
     # enable or disable analyzers by name
     disable:

--- a/pkg/storage/protocol/buffered_writer.go
+++ b/pkg/storage/protocol/buffered_writer.go
@@ -1,0 +1,151 @@
+package protocol
+
+import (
+	"bytes"
+	"io"
+	"sync"
+	"time"
+)
+
+type WriterWithUrgent interface {
+	io.Writer
+	WriteNow([]byte) (int, error)
+}
+
+type BufferedWriterConfig struct {
+	Timeout    time.Duration // Delay a flush by this amount
+	DelayTimer bool          // If true, the delayed flush gets rescheduled each write
+	MaxLength  int           // Max data to buffer. If more, we will flush on write
+}
+
+type BufferedWriter struct {
+	w          io.Writer
+	lock       sync.Mutex
+	buffer     bytes.Buffer
+	timeout    time.Duration
+	maxLength  int
+	delayTimer bool
+	flushTimer *time.Timer
+	flushErr   chan error
+}
+
+/**
+ *
+ *
+ */
+func NewBufferedWriter(w io.Writer, config *BufferedWriterConfig) *BufferedWriter {
+	return &BufferedWriter{
+		w:          w,
+		timeout:    config.Timeout,
+		delayTimer: config.DelayTimer,
+		maxLength:  config.MaxLength,
+		flushErr:   make(chan error, 1),
+	}
+}
+
+// Write with a forced flush
+func (bw *BufferedWriter) WriteNow(buffer []byte) (int, error) {
+	// See if there's any error to report from delayed flushing.
+	select {
+	case err := <-bw.flushErr:
+		return 0, err
+	default:
+	}
+
+	bw.lock.Lock()
+	bw.buffer.Write(buffer)
+
+	// Flush the data now, and clear the buffer
+	data := bw.buffer.Bytes()
+	bw.buffer.Reset()
+	bw.lock.Unlock()
+
+	n, err := bw.w.Write(data)
+	return n, err
+}
+
+// Write with a delayed flush
+func (bw *BufferedWriter) Write(buffer []byte) (int, error) {
+	// See if there's any error to report from delayed flushing.
+	select {
+	case err := <-bw.flushErr:
+		return 0, err
+	default:
+	}
+
+	bw.lock.Lock()
+	if bw.flushTimer == nil || bw.delayTimer {
+		if bw.delayTimer && bw.flushTimer != nil {
+			// Cancel any existing timer here...
+			bw.flushTimer.Stop()
+			bw.flushTimer = nil
+		}
+
+		// If we don't currently have a timer setup, set one up here.
+		if bw.flushTimer == nil {
+			// Schedule a flush...
+			bw.flushTimer = time.AfterFunc(bw.timeout, func() {
+				bw.lock.Lock()
+				bw.flushTimer = nil
+				// Nothing to do anyway
+				if bw.buffer.Len() == 0 {
+					bw.lock.Unlock()
+					return
+				}
+				data := bw.buffer.Bytes()
+
+				_, err := bw.w.Write(data)
+				bw.buffer.Reset()
+				bw.lock.Unlock()
+				if err != nil {
+					// Put the error in flushErr
+					select {
+					case bw.flushErr <- err:
+					default:
+					}
+				}
+			})
+		}
+	}
+	bw.buffer.Write(buffer)
+	if bw.buffer.Len() >= bw.maxLength {
+		// Flush the data now, and clear the buffer
+		data := bw.buffer.Bytes()
+		n, err := bw.w.Write(data)
+		bw.buffer.Reset()
+		bw.lock.Unlock()
+		return n, err
+	}
+	bw.lock.Unlock()
+
+	// Report no error
+	return len(buffer), nil
+}
+
+// Flush all data
+func (bw *BufferedWriter) Flush() error {
+	// See if there's any error to report from delayed flushing.
+	select {
+	case err := <-bw.flushErr:
+		return err
+	default:
+	}
+
+	bw.lock.Lock()
+	// Clear any existing timed flush.
+	if bw.flushTimer != nil {
+		bw.flushTimer.Stop()
+		bw.flushTimer = nil
+	}
+	// Nothing to do anyway
+	if bw.buffer.Len() == 0 {
+		bw.lock.Unlock()
+		return nil
+	}
+	data := bw.buffer.Bytes()
+	bw.buffer.Reset()
+	bw.lock.Unlock()
+
+	_, err := bw.w.Write(data)
+	return err
+}

--- a/pkg/storage/protocol/buffered_writer_test.go
+++ b/pkg/storage/protocol/buffered_writer_test.go
@@ -1,0 +1,139 @@
+package protocol_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/loopholelabs/silo/pkg/storage/protocol"
+	"github.com/stretchr/testify/assert"
+)
+
+type loggedWriter struct {
+	writes []int
+	err    chan error
+}
+
+func (lw *loggedWriter) Write(buffer []byte) (int, error) {
+	// Return an error if one has been set
+	select {
+	case err := <-lw.err:
+		return 0, err
+	default:
+	}
+	// Just log it
+	lw.writes = append(lw.writes, len(buffer))
+	return len(buffer), nil
+}
+
+func newLoggedWriter() *loggedWriter {
+	return &loggedWriter{
+		writes: make([]int, 0),
+		err:    make(chan error, 1),
+	}
+}
+
+func TestBufferedWriter(t *testing.T) {
+	w := newLoggedWriter()
+	bw := protocol.NewBufferedWriter(w, &protocol.BufferedWriterConfig{Timeout: 1 * time.Minute, DelayTimer: true, MaxLength: 100})
+	for i := 0; i < 10; i++ {
+		data := make([]byte, 50)
+		_, err := bw.Write(data)
+		assert.NoError(t, err)
+	}
+
+	err := bw.Flush()
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int{100, 100, 100, 100, 100}, w.writes)
+}
+
+func TestBufferedWriterTimed(t *testing.T) {
+	w := newLoggedWriter()
+	bw := protocol.NewBufferedWriter(w, &protocol.BufferedWriterConfig{Timeout: 100 * time.Millisecond, DelayTimer: true, MaxLength: 1000000})
+	for i := 0; i < 10; i++ {
+		data := make([]byte, 50)
+		_, err := bw.Write(data)
+		assert.NoError(t, err)
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	for i := 0; i < 10; i++ {
+		data := make([]byte, 50)
+		_, err := bw.Write(data)
+		assert.NoError(t, err)
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	err := bw.Flush()
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int{500, 500}, w.writes)
+}
+
+func TestBufferedWriterNow(t *testing.T) {
+	w := newLoggedWriter()
+	bw := protocol.NewBufferedWriter(w, &protocol.BufferedWriterConfig{Timeout: 100 * time.Second, DelayTimer: true, MaxLength: 1000000})
+	data := make([]byte, 50)
+	for i := 0; i < 10; i++ {
+		_, err := bw.Write(data)
+		assert.NoError(t, err)
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	_, err := bw.WriteNow(data) // This will do a flush
+	assert.NoError(t, err)
+
+	assert.Equal(t, []int{550}, w.writes)
+}
+
+func TestBufferedWriterError(t *testing.T) {
+	w := newLoggedWriter()
+	bw := protocol.NewBufferedWriter(w, &protocol.BufferedWriterConfig{Timeout: 100 * time.Millisecond, DelayTimer: true, MaxLength: 1000000})
+	data := make([]byte, 50)
+	for i := 0; i < 10; i++ {
+		_, err := bw.Write(data)
+		assert.NoError(t, err)
+		time.Sleep(20 * time.Millisecond)
+	}
+	someError := errors.New("Hello")
+	w.err <- someError
+
+	// Make sure a write happens here, which has an error
+	time.Sleep(200 * time.Millisecond)
+
+	// The write failed, so it won't have been recorded
+	assert.Equal(t, []int{}, w.writes)
+
+	// Make sure any write results in the error now...
+	_, err := bw.Write(data)
+	assert.ErrorIs(t, someError, err)
+}
+
+func TestBufferedWriterDelayTimerFalse(t *testing.T) {
+	w := newLoggedWriter()
+	bw := protocol.NewBufferedWriter(w, &protocol.BufferedWriterConfig{Timeout: 100 * time.Millisecond, DelayTimer: false, MaxLength: 1000000})
+	data := make([]byte, 50)
+	for i := 0; i < 10; i++ {
+		_, err := bw.Write(data)
+		assert.NoError(t, err)
+		time.Sleep(20 * time.Millisecond)
+	}
+	// Should have written something by now, since the timer is not reset...
+	assert.Greater(t, len(w.writes), 0)
+}
+
+func TestBufferedWriterDelayTimerTrue(t *testing.T) {
+	w := newLoggedWriter()
+	bw := protocol.NewBufferedWriter(w, &protocol.BufferedWriterConfig{Timeout: 100 * time.Millisecond, DelayTimer: true, MaxLength: 1000000})
+	data := make([]byte, 50)
+	for i := 0; i < 10; i++ {
+		_, err := bw.Write(data)
+		assert.NoError(t, err)
+		time.Sleep(20 * time.Millisecond)
+	}
+	// Nothing should have been written, since the timer gets delayed each time
+	assert.Equal(t, 0, len(w.writes))
+}

--- a/pkg/storage/protocol/from_protocol.go
+++ b/pkg/storage/protocol/from_protocol.go
@@ -172,7 +172,7 @@ func (fp *FromProtocol) HandleEvent(cb func(*packets.Event)) error {
 		// Relay the event, wait, and then respond.
 		cb(ev)
 
-		_, err = fp.protocol.SendPacket(fp.dev, id, packets.EncodeEventResponse())
+		_, err = fp.protocol.SendPacket(fp.dev, id, packets.EncodeEventResponse(), UrgencyUrgent)
 		if err != nil {
 			return err
 		}
@@ -199,7 +199,7 @@ func (fp *FromProtocol) HandleHashes(cb func(map[uint][sha256.Size]byte)) error 
 		// Relay the hashes, wait and then respond
 		cb(hashes)
 
-		_, err = fp.protocol.SendPacket(fp.dev, id, packets.EncodeHashesResponse())
+		_, err = fp.protocol.SendPacket(fp.dev, id, packets.EncodeHashesResponse(), UrgencyUrgent)
 		if err != nil {
 			return err
 		}
@@ -283,7 +283,7 @@ func (fp *FromProtocol) HandleReadAt() error {
 				Error: err,
 				Data:  buff,
 			}
-			_, err = fp.protocol.SendPacket(fp.dev, gid, packets.EncodeReadAtResponse(rar))
+			_, err = fp.protocol.SendPacket(fp.dev, gid, packets.EncodeReadAtResponse(rar), UrgencyNormal)
 			if err != nil {
 				errLock.Lock()
 				errValue = err
@@ -331,7 +331,7 @@ func (fp *FromProtocol) HandleWriteAt() error {
 				Error: nil,
 				Bytes: int(length),
 			}
-			_, err = fp.protocol.SendPacket(fp.dev, id, packets.EncodeWriteAtResponse(war))
+			_, err = fp.protocol.SendPacket(fp.dev, id, packets.EncodeWriteAtResponse(war), UrgencyNormal)
 			if err != nil {
 				return err
 			}
@@ -359,7 +359,7 @@ func (fp *FromProtocol) HandleWriteAt() error {
 				if err == nil {
 					fp.markRangePresent(int(goffset), len(gdata))
 				}
-				_, err = fp.protocol.SendPacket(fp.dev, gid, packets.EncodeWriteAtResponse(war))
+				_, err = fp.protocol.SendPacket(fp.dev, gid, packets.EncodeWriteAtResponse(war), UrgencyNormal)
 				if err != nil {
 					errLock.Lock()
 					errValue = err
@@ -396,7 +396,7 @@ func (fp *FromProtocol) HandleWriteAtWithMap(cb func(offset int64, data []byte, 
 			Bytes: len(writeData),
 			Error: err,
 		}
-		_, err = fp.protocol.SendPacket(fp.dev, id, packets.EncodeWriteAtResponse(war))
+		_, err = fp.protocol.SendPacket(fp.dev, id, packets.EncodeWriteAtResponse(war), UrgencyNormal)
 		if err != nil {
 			return err
 		}
@@ -478,7 +478,7 @@ func (fp *FromProtocol) HandleDirtyList(cb func(blocks []uint)) error {
 		cb(blocks)
 
 		// Send a response / ack, to signify that the DirtyList has been actioned.
-		_, err = fp.protocol.SendPacket(fp.dev, gid, packets.EncodeDirtyListResponse())
+		_, err = fp.protocol.SendPacket(fp.dev, gid, packets.EncodeDirtyListResponse(), UrgencyUrgent)
 		if err != nil {
 			return err
 		}
@@ -487,12 +487,12 @@ func (fp *FromProtocol) HandleDirtyList(cb func(blocks []uint)) error {
 
 func (fp *FromProtocol) NeedAt(offset int64, length int32) error {
 	b := packets.EncodeNeedAt(offset, length)
-	_, err := fp.protocol.SendPacket(fp.dev, IDPickAny, b)
+	_, err := fp.protocol.SendPacket(fp.dev, IDPickAny, b, UrgencyUrgent)
 	return err
 }
 
 func (fp *FromProtocol) DontNeedAt(offset int64, length int32) error {
 	b := packets.EncodeDontNeedAt(offset, length)
-	_, err := fp.protocol.SendPacket(fp.dev, IDPickAny, b)
+	_, err := fp.protocol.SendPacket(fp.dev, IDPickAny, b, UrgencyUrgent)
 	return err
 }

--- a/pkg/storage/protocol/mock_protocol.go
+++ b/pkg/storage/protocol/mock_protocol.go
@@ -23,7 +23,7 @@ func NewMockProtocol(ctx context.Context) *MockProtocol {
 	}
 }
 
-func (mp *MockProtocol) SendPacket(dev uint32, id uint32, data []byte, urgency Urgency) (uint32, error) {
+func (mp *MockProtocol) SendPacket(dev uint32, id uint32, data []byte, _ Urgency) (uint32, error) {
 	cmd := data[0]
 
 	// if id is ANY, pick one

--- a/pkg/storage/protocol/mock_protocol.go
+++ b/pkg/storage/protocol/mock_protocol.go
@@ -1,9 +1,7 @@
 package protocol
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"sync"
 	"sync/atomic"
 
@@ -23,16 +21,6 @@ func NewMockProtocol(ctx context.Context) *MockProtocol {
 		waiters: make(map[uint32]Waiters),
 		tid:     0,
 	}
-}
-
-func (mp *MockProtocol) SendPacketWriter(dev uint32, id uint32, _ uint32, data func(io.Writer) error) (uint32, error) {
-	var buff bytes.Buffer
-	err := data(&buff)
-	if err != nil {
-		return 0, err
-	}
-
-	return mp.SendPacket(dev, id, buff.Bytes())
 }
 
 func (mp *MockProtocol) SendPacket(dev uint32, id uint32, data []byte) (uint32, error) {

--- a/pkg/storage/protocol/mock_protocol.go
+++ b/pkg/storage/protocol/mock_protocol.go
@@ -23,7 +23,7 @@ func NewMockProtocol(ctx context.Context) *MockProtocol {
 	}
 }
 
-func (mp *MockProtocol) SendPacket(dev uint32, id uint32, data []byte) (uint32, error) {
+func (mp *MockProtocol) SendPacket(dev uint32, id uint32, data []byte, urgency Urgency) (uint32, error) {
 	cmd := data[0]
 
 	// if id is ANY, pick one

--- a/pkg/storage/protocol/packets/write_at.go
+++ b/pkg/storage/protocol/packets/write_at.go
@@ -2,7 +2,6 @@ package packets
 
 import (
 	"encoding/binary"
-	"io"
 )
 
 const WriteAtData = 0
@@ -16,21 +15,6 @@ func EncodeWriteAt(offset int64, data []byte) []byte {
 	binary.LittleEndian.PutUint64(buff[2:], uint64(offset))
 	copy(buff[10:], data)
 	return buff
-}
-
-func EncodeWriterWriteAt(offset int64, data []byte) (uint32, func(w io.Writer) error) {
-	return uint32(10 + len(data)), func(w io.Writer) error {
-		header := make([]byte, 2+8)
-		header[0] = CommandWriteAt
-		header[1] = WriteAtData
-		binary.LittleEndian.PutUint64(header[2:], uint64(offset))
-		_, err := w.Write(header)
-		if err != nil {
-			return err
-		}
-		_, err = w.Write(data)
-		return err
-	}
 }
 
 func DecodeWriteAt(buff []byte) (offset int64, data []byte, err error) {

--- a/pkg/storage/protocol/protocol.go
+++ b/pkg/storage/protocol/protocol.go
@@ -2,9 +2,14 @@ package protocol
 
 const IDPickAny = 0
 
+type Urgency int
+
+const UrgencyNormal = Urgency(0)
+const UrgencyUrgent = Urgency(1)
+
 type Protocol interface {
 	// Send a packet (Returns a transaction id)
-	SendPacket(dev uint32, id uint32, data []byte) (uint32, error)
+	SendPacket(dev uint32, id uint32, data []byte, urgency Urgency) (uint32, error)
 
 	// Wait for a response packet (Given specific transaction id)
 	WaitForPacket(dev uint32, id uint32) ([]byte, error)

--- a/pkg/storage/protocol/protocol.go
+++ b/pkg/storage/protocol/protocol.go
@@ -1,15 +1,10 @@
 package protocol
 
-import "io"
-
 const IDPickAny = 0
 
 type Protocol interface {
 	// Send a packet (Returns a transaction id)
 	SendPacket(dev uint32, id uint32, data []byte) (uint32, error)
-
-	// Send a packet using a callback to write the data
-	SendPacketWriter(dev uint32, id uint32, length uint32, data func(w io.Writer) error) (uint32, error)
 
 	// Wait for a response packet (Given specific transaction id)
 	WaitForPacket(dev uint32, id uint32) ([]byte, error)

--- a/pkg/storage/protocol/protocol_rw.go
+++ b/pkg/storage/protocol/protocol_rw.go
@@ -82,7 +82,7 @@ func (p *RW) InitDev(dev uint32) {
 }
 
 // Send a packet
-func (p *RW) SendPacket(dev uint32, id uint32, data []byte) (uint32, error) {
+func (p *RW) SendPacket(dev uint32, id uint32, data []byte, urgency Urgency) (uint32, error) {
 	// If the context was cancelled, we should return that error
 	select {
 	case <-p.ctx.Done():

--- a/pkg/storage/protocol/protocol_rw.go
+++ b/pkg/storage/protocol/protocol_rw.go
@@ -37,6 +37,10 @@ type RW struct {
 }
 
 func NewRW(ctx context.Context, readers []io.Reader, writers []io.Writer, newdevFN func(context.Context, Protocol, uint32)) *RW {
+	return NewRWWithBuffering(ctx, readers, writers, nil, newdevFN)
+}
+
+func NewRWWithBuffering(ctx context.Context, readers []io.Reader, writers []io.Writer, bufferConfig *BufferedWriterConfig, newdevFN func(context.Context, Protocol, uint32)) *RW {
 	prw := &RW{
 		ctx:        ctx,
 		waiters:    make(map[uint32]Waiters),
@@ -46,7 +50,15 @@ func NewRW(ctx context.Context, readers []io.Reader, writers []io.Writer, newdev
 
 	prw.readers = readers
 
-	prw.writers = writers
+	prw.writers = make([]io.Writer, 0)
+	for _, w := range writers {
+		if bufferConfig != nil {
+			prw.writers = append(prw.writers, NewBufferedWriter(w, bufferConfig))
+		} else {
+			prw.writers = append(prw.writers, w)
+		}
+	}
+
 	prw.writerLocks = make([]sync.Mutex, len(writers))
 	prw.writerHeaders = make([][]byte, len(writers))
 	for i := 0; i < len(writers); i++ {
@@ -112,7 +124,15 @@ func (p *RW) SendPacket(dev uint32, id uint32, data []byte, urgency Urgency) (ui
 	if err != nil {
 		return 0, err
 	}
-	_, err = p.writers[i].Write(data)
+
+	// If it's urgent, then use WriteNow if we can
+	wwu, ok := p.writers[i].(WriterWithUrgent)
+	if urgency == UrgencyUrgent && ok {
+		_, err = wwu.WriteNow(data)
+	} else {
+		_, err = p.writers[i].Write(data)
+	}
+
 	return id, err
 }
 

--- a/pkg/storage/protocol/protocol_rw_test.go
+++ b/pkg/storage/protocol/protocol_rw_test.go
@@ -170,7 +170,7 @@ func TestProtocolRWSendAfterCancel(t *testing.T) {
 
 	// Now check that we can't send anything...
 
-	_, err = prDest.SendPacket(1, 0, []byte{1, 2, 3})
+	_, err = prDest.SendPacket(1, 0, []byte{1, 2, 3}, UrgencyUrgent)
 	assert.ErrorIs(t, err, context.Canceled)
 
 }

--- a/pkg/storage/protocol/protocol_rw_test.go
+++ b/pkg/storage/protocol/protocol_rw_test.go
@@ -173,7 +173,4 @@ func TestProtocolRWSendAfterCancel(t *testing.T) {
 	_, err = prDest.SendPacket(1, 0, []byte{1, 2, 3})
 	assert.ErrorIs(t, err, context.Canceled)
 
-	_, err = prDest.SendPacketWriter(1, 0, 0, func(_ io.Writer) error { return nil })
-	assert.ErrorIs(t, err, context.Canceled)
-
 }

--- a/pkg/storage/protocol/test_protocol_bandwidth.go
+++ b/pkg/storage/protocol/test_protocol_bandwidth.go
@@ -64,8 +64,8 @@ func (p *TestProtocolBandwidth) expireBandwidth(since time.Duration) {
 	p.recentPackets = newRecentPackets
 }
 
-func (p *TestProtocolBandwidth) SendPacket(dev uint32, id uint32, data []byte) (uint32, error) {
-	return p.proto.SendPacket(dev, id, data)
+func (p *TestProtocolBandwidth) SendPacket(dev uint32, id uint32, data []byte, urgency Urgency) (uint32, error) {
+	return p.proto.SendPacket(dev, id, data, urgency)
 }
 
 func (p *TestProtocolBandwidth) waitForBandwidth() {

--- a/pkg/storage/protocol/test_protocol_bandwidth.go
+++ b/pkg/storage/protocol/test_protocol_bandwidth.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"io"
 	"sync"
 	"time"
 )
@@ -63,10 +62,6 @@ func (p *TestProtocolBandwidth) expireBandwidth(since time.Duration) {
 		}
 	}
 	p.recentPackets = newRecentPackets
-}
-
-func (p *TestProtocolBandwidth) SendPacketWriter(dev uint32, id uint32, length uint32, data func(w io.Writer) error) (uint32, error) {
-	return p.proto.SendPacketWriter(dev, id, length, data)
 }
 
 func (p *TestProtocolBandwidth) SendPacket(dev uint32, id uint32, data []byte) (uint32, error) {

--- a/pkg/storage/protocol/test_protocol_latency.go
+++ b/pkg/storage/protocol/test_protocol_latency.go
@@ -26,8 +26,8 @@ func NewTestProtocolLatency(proto Protocol, recvLatency time.Duration) Protocol 
 	return p
 }
 
-func (p *TestProtocolLatency) SendPacket(dev uint32, id uint32, data []byte) (uint32, error) {
-	return p.proto.SendPacket(dev, id, data)
+func (p *TestProtocolLatency) SendPacket(dev uint32, id uint32, data []byte, urgency Urgency) (uint32, error) {
+	return p.proto.SendPacket(dev, id, data, urgency)
 }
 
 func (p *TestProtocolLatency) WaitForPacket(dev uint32, id uint32) ([]byte, error) {

--- a/pkg/storage/protocol/test_protocol_latency.go
+++ b/pkg/storage/protocol/test_protocol_latency.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"io"
 	"sync/atomic"
 	"time"
 )
@@ -25,10 +24,6 @@ func NewTestProtocolLatency(proto Protocol, recvLatency time.Duration) Protocol 
 
 	p.isFirst.Store(true)
 	return p
-}
-
-func (p *TestProtocolLatency) SendPacketWriter(dev uint32, id uint32, length uint32, data func(w io.Writer) error) (uint32, error) {
-	return p.proto.SendPacketWriter(dev, id, length, data)
 }
 
 func (p *TestProtocolLatency) SendPacket(dev uint32, id uint32, data []byte) (uint32, error) {

--- a/pkg/storage/protocol/to_protocol.go
+++ b/pkg/storage/protocol/to_protocol.go
@@ -154,8 +154,8 @@ func (i *ToProtocol) WriteAt(buffer []byte, offset int64) (int, error) {
 			data := packets.EncodeWriteAtComp(offset, buffer)
 			id, err = i.protocol.SendPacket(i.dev, IDPickAny, data)
 		} else {
-			l, f := packets.EncodeWriterWriteAt(offset, buffer)
-			id, err = i.protocol.SendPacketWriter(i.dev, IDPickAny, l, f)
+			data := packets.EncodeWriteAt(offset, buffer)
+			id, err = i.protocol.SendPacket(i.dev, IDPickAny, data)
 		}
 	}
 	if err != nil {

--- a/pkg/storage/protocol/to_protocol_test.go
+++ b/pkg/storage/protocol/to_protocol_test.go
@@ -29,7 +29,7 @@ type sendPacketInfo struct {
 	data []byte
 }
 
-func (p *MockPro) SendPacket(dev uint32, id uint32, data []byte, urgency Urgency) (uint32, error) {
+func (p *MockPro) SendPacket(dev uint32, id uint32, data []byte, _ Urgency) (uint32, error) {
 	mockID := uint32(999)
 	p.sendPackets <- &sendPacketInfo{
 		dev:  dev,

--- a/pkg/storage/protocol/to_protocol_test.go
+++ b/pkg/storage/protocol/to_protocol_test.go
@@ -29,7 +29,7 @@ type sendPacketInfo struct {
 	data []byte
 }
 
-func (p *MockPro) SendPacket(dev uint32, id uint32, data []byte) (uint32, error) {
+func (p *MockPro) SendPacket(dev uint32, id uint32, data []byte, urgency Urgency) (uint32, error) {
 	mockID := uint32(999)
 	p.sendPackets <- &sendPacketInfo{
 		dev:  dev,

--- a/pkg/storage/protocol/to_protocol_test.go
+++ b/pkg/storage/protocol/to_protocol_test.go
@@ -1,10 +1,8 @@
 package protocol
 
 import (
-	"bytes"
 	"crypto/rand"
 	"errors"
-	"io"
 	"testing"
 
 	"github.com/loopholelabs/silo/pkg/storage/protocol/packets"
@@ -29,21 +27,6 @@ type sendPacketInfo struct {
 	dev  uint32
 	id   uint32
 	data []byte
-}
-
-func (p *MockPro) SendPacketWriter(dev uint32, id uint32, _ uint32, data func(w io.Writer) error) (uint32, error) {
-	var buff bytes.Buffer
-	err := data(&buff)
-	if err != nil {
-		return 0, err
-	}
-	mockID := uint32(999)
-	p.sendPackets <- &sendPacketInfo{
-		dev:  dev,
-		id:   mockID,
-		data: buff.Bytes(),
-	}
-	return id, nil
 }
 
 func (p *MockPro) SendPacket(dev uint32, id uint32, data []byte) (uint32, error) {

--- a/pkg/storage/util/bitfield.go
+++ b/pkg/storage/util/bitfield.go
@@ -440,8 +440,8 @@ func (bf *Bitfield) Equals(bf2 *Bitfield) bool {
 
 // Create a mask of bits at the start of this range
 func maskStart(start, end uint) (mask uint64) {
-	const max = ^uint64(0)
-	return ((max << (start & 63)) ^ (max << (end - start&^63))) & ((1 >> (start & 63)) - 1)
+	const maxUint64 = ^uint64(0)
+	return ((maxUint64 << (start & 63)) ^ (maxUint64 << (end - start&^63))) & ((1 >> (start & 63)) - 1)
 }
 
 // Create a mask of bits at the end of this range


### PR DESCRIPTION
Silo can send lots of packets. This can result in a lot of Write() calls to the underlying transport.
This PR adds a bufferedWriter which can combine several packets into larger write operations, which can be beneficial in certain setups.
Some packets are "urgent", for example Events, and for this reason the PR includes provision for bypassing buffering - ensuring that the packet in question will get sent immediately.

The BufferedWriter includes a configuration:
* Timeout - this is the delay for flushing the write, while collecting other write data.
* DelayTimer - if true, then each write reschedules the flush. In this mode, continuous writing may result in no flush until we have reached the MaxLength threshold
* MaxLength - maximum length of data we will buffer. If the buffer is larger, then we will flush in the Write() call immediately.

This will not result in performance increase in all situations, but gives us options if we need to minimize or just reduce the number of Write() calls.