### PR TITLE
Fixed up toProtocol compressed write flag

### DIFF
--- a/pkg/storage/migrator/migrator_benchmark_test.go
+++ b/pkg/storage/migrator/migrator_benchmark_test.go
@@ -200,7 +200,7 @@ func BenchmarkMigrationPipe(mb *testing.B) {
 			destination := protocol.NewToProtocol(sourceDirtyRemote.Size(), 17, prSource)
 
 			if testconf.compress {
-				destination.CompressedWrites = true
+				destination.SetCompression(true)
 			}
 
 			err = destination.SendDevInfo("test", uint32(blockSize), "")

--- a/pkg/storage/protocol/protocol_transport_benchmark_test.go
+++ b/pkg/storage/protocol/protocol_transport_benchmark_test.go
@@ -106,7 +106,7 @@ func BenchmarkWriteAt(mb *testing.B) {
 func BenchmarkWriteAtComp(mb *testing.B) {
 	sourceToProtocol := setup(1)
 
-	sourceToProtocol.CompressedWrites = true
+	sourceToProtocol.SetCompression(true)
 
 	// Do some writes
 	buff := make([]byte, 256*1024)

--- a/pkg/storage/protocol/protocol_transport_test.go
+++ b/pkg/storage/protocol/protocol_transport_test.go
@@ -73,7 +73,7 @@ func TestProtocolWriteAtComp(t *testing.T) {
 
 	sourceToProtocol := NewToProtocol(uint64(size), 1, pr)
 
-	sourceToProtocol.CompressedWrites = true
+	sourceToProtocol.SetCompression(true)
 
 	storeFactory := func(di *packets.DevInfo) storage.Provider {
 		store = sources.NewMemoryStorage(int(di.Size))


### PR DESCRIPTION
This PR fixes a potential issue with concurrent access to bool in ToProtocol. It replaces it with an explicit SetCompression() call which uses atomic.Bool internally.