### PR TITLE
dg WaitingCache is now inserted in the correct place

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -91,7 +91,7 @@ func runServe(_ *cobra.Command, _ []string) {
 		panic(err)
 	}
 
-	dg, err := devicegroup.NewFromSchema(siloConf.Device, log, siloMetrics)
+	dg, err := devicegroup.NewFromSchema(siloConf.Device, false, log, siloMetrics)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/storage/devicegroup/device_group_from.go
+++ b/pkg/storage/devicegroup/device_group_from.go
@@ -10,7 +10,6 @@ import (
 	"github.com/loopholelabs/silo/pkg/storage/metrics"
 	"github.com/loopholelabs/silo/pkg/storage/protocol"
 	"github.com/loopholelabs/silo/pkg/storage/protocol/packets"
-	"github.com/loopholelabs/silo/pkg/storage/waitingcache"
 )
 
 func NewFromProtocol(ctx context.Context,
@@ -85,7 +84,7 @@ func NewFromProtocol(ctx context.Context,
 		devices[index-1] = ds
 	}
 
-	dg, err := NewFromSchema(devices, log, met)
+	dg, err := NewFromSchema(devices, true, log, met)
 	if err != nil {
 		return nil, err
 	}
@@ -102,12 +101,13 @@ func NewFromProtocol(ctx context.Context,
 		d.EventHandler = eventHandler
 
 		destStorageFactory := func(di *packets.DevInfo) storage.Provider {
-			d.WaitingCacheLocal, d.WaitingCacheRemote = waitingcache.NewWaitingCacheWithLogger(d.Prov, int(di.BlockSize), dg.log)
+			/*
+				d.WaitingCacheLocal, d.WaitingCacheRemote = waitingcache.NewWaitingCacheWithLogger(d.Prov, int(di.BlockSize), dg.log)
 
-			if d.Exp != nil {
-				d.Exp.SetProvider(d.WaitingCacheLocal)
-			}
-
+				if d.Exp != nil {
+					d.Exp.SetProvider(d.WaitingCacheLocal)
+				}
+			*/
 			return d.WaitingCacheRemote
 		}
 

--- a/pkg/storage/devicegroup/device_group_from.go
+++ b/pkg/storage/devicegroup/device_group_from.go
@@ -100,7 +100,7 @@ func NewFromProtocol(ctx context.Context,
 		d := dg.devices[dev]
 		d.EventHandler = eventHandler
 
-		destStorageFactory := func(di *packets.DevInfo) storage.Provider {
+		destStorageFactory := func(_ *packets.DevInfo) storage.Provider {
 			/*
 				d.WaitingCacheLocal, d.WaitingCacheRemote = waitingcache.NewWaitingCacheWithLogger(d.Prov, int(di.BlockSize), dg.log)
 

--- a/pkg/storage/devicegroup/device_group_test.go
+++ b/pkg/storage/devicegroup/device_group_test.go
@@ -53,7 +53,7 @@ func setupDeviceGroup(t *testing.T) *DeviceGroup {
 			return nil
 		}
 	*/
-	dg, err := NewFromSchema(testDeviceSchema, nil, nil)
+	dg, err := NewFromSchema(testDeviceSchema, false, nil, nil)
 	assert.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pkg/storage/devicegroup/device_group_to.go
+++ b/pkg/storage/devicegroup/device_group_to.go
@@ -48,7 +48,7 @@ func NewFromSchema(ds []*config.DeviceSchema, createWC bool, log types.Logger, m
 		var waitingCacheLocal *waitingcache.Local
 		var waitingCacheRemote *waitingcache.Remote
 		if createWC {
-			waitingCacheLocal, waitingCacheRemote = waitingcache.NewWaitingCacheWithLogger(prov, int(blockSize), dg.log)
+			waitingCacheLocal, waitingCacheRemote = waitingcache.NewWaitingCacheWithLogger(prov, blockSize, dg.log)
 			prov = waitingCacheLocal
 		}
 

--- a/pkg/storage/devicegroup/device_group_to.go
+++ b/pkg/storage/devicegroup/device_group_to.go
@@ -17,9 +17,10 @@ import (
 	"github.com/loopholelabs/silo/pkg/storage/protocol"
 	"github.com/loopholelabs/silo/pkg/storage/protocol/packets"
 	"github.com/loopholelabs/silo/pkg/storage/volatilitymonitor"
+	"github.com/loopholelabs/silo/pkg/storage/waitingcache"
 )
 
-func NewFromSchema(ds []*config.DeviceSchema, log types.Logger, met metrics.SiloMetrics) (*DeviceGroup, error) {
+func NewFromSchema(ds []*config.DeviceSchema, createWC bool, log types.Logger, met metrics.SiloMetrics) (*DeviceGroup, error) {
 	dg := &DeviceGroup{
 		log:      log,
 		met:      met,
@@ -42,6 +43,13 @@ func NewFromSchema(ds []*config.DeviceSchema, log types.Logger, met metrics.Silo
 		blockSize := int(s.ByteBlockSize())
 		if blockSize == 0 {
 			blockSize = defaultBlockSize
+		}
+
+		var waitingCacheLocal *waitingcache.Local
+		var waitingCacheRemote *waitingcache.Remote
+		if createWC {
+			waitingCacheLocal, waitingCacheRemote = waitingcache.NewWaitingCacheWithLogger(prov, int(blockSize), dg.log)
+			prov = waitingCacheLocal
 		}
 
 		local := modules.NewLockable(prov)
@@ -68,17 +76,19 @@ func NewFromSchema(ds []*config.DeviceSchema, log types.Logger, met metrics.Silo
 		}
 
 		dg.devices = append(dg.devices, &DeviceInformation{
-			Size:        local.Size(),
-			BlockSize:   uint64(blockSize),
-			NumBlocks:   totalBlocks,
-			Schema:      s,
-			Prov:        prov,
-			Storage:     local,
-			Exp:         exp,
-			Volatility:  vmonitor,
-			DirtyLocal:  dirtyLocal,
-			DirtyRemote: dirtyRemote,
-			Orderer:     orderer,
+			Size:               local.Size(),
+			BlockSize:          uint64(blockSize),
+			NumBlocks:          totalBlocks,
+			Schema:             s,
+			Prov:               prov,
+			Storage:            local,
+			Exp:                exp,
+			Volatility:         vmonitor,
+			DirtyLocal:         dirtyLocal,
+			DirtyRemote:        dirtyRemote,
+			Orderer:            orderer,
+			WaitingCacheLocal:  waitingCacheLocal,
+			WaitingCacheRemote: waitingCacheRemote,
 		})
 
 		// Set these two at least, so we know *something* about every device in progress handler.


### PR DESCRIPTION
This fixes an issue whereby an incoming dg would receive writes, but a migrateTo would not pick up those writes correctly.

The waitingCache was being inserted incorrectly. This hopefully fixes that.