### PR TITLE
Add missing `nil` err check

### DIFF
--- a/pkg/storage/sources/s3_storage.go
+++ b/pkg/storage/sources/s3_storage.go
@@ -192,7 +192,7 @@ func (i *S3Storage) ReadAt(buffer []byte, offset int64) (int, error) {
 			atomic.AddUint64(&i.metricsBlocksRCount, 1)
 			atomic.AddUint64(&i.metricsBlocksRBytes, uint64(n))
 			atomic.AddUint64(&i.metricsBlocksRTimeNS, uint64(dtime.Nanoseconds()))
-		} else if err.Error() == errNoSuchKey.Error() {
+		} else if err != nil && err.Error() == errNoSuchKey.Error() {
 			return len(buff), nil
 		}
 


### PR DESCRIPTION
During S3 migrations we compare an `err` value to an error without checking if that `err` is `nil` first. This PR fixes that.