### PR TITLE
custom event listener now correctly exits when context cancelled

### DIFF
--- a/pkg/storage/devicegroup/device_group_from.go
+++ b/pkg/storage/devicegroup/device_group_from.go
@@ -64,7 +64,7 @@ func NewFromProtocol(ctx context.Context,
 	go func() {
 		for {
 			err := handleCustomDataEvent()
-			if err != nil && !errors.Is(err, context.Canceled) {
+			if err != nil {
 				log.Debug().Err(err).Msg("handleCustomDataEvenet returned")
 				return
 			}

--- a/pkg/storage/devicegroup/device_group_from.go
+++ b/pkg/storage/devicegroup/device_group_from.go
@@ -65,7 +65,9 @@ func NewFromProtocol(ctx context.Context,
 		for {
 			err := handleCustomDataEvent()
 			if err != nil {
-				log.Debug().Err(err).Msg("handleCustomDataEvenet returned")
+				if log != nil {
+					log.Debug().Err(err).Msg("handleCustomDataEvenet returned")
+				}
 				return
 			}
 		}
@@ -119,13 +121,17 @@ func NewFromProtocol(ctx context.Context,
 		go func() {
 			err := from.HandleReadAt()
 			if err != nil && !errors.Is(err, context.Canceled) {
-				log.Debug().Err(err).Msg("HandleReadAt returned")
+				if log != nil {
+					log.Debug().Err(err).Msg("HandleReadAt returned")
+				}
 			}
 		}()
 		go func() {
 			err := from.HandleWriteAt()
 			if err != nil && !errors.Is(err, context.Canceled) {
-				log.Debug().Err(err).Msg("HandleWriteAt returned")
+				if log != nil {
+					log.Debug().Err(err).Msg("HandleWriteAt returned")
+				}
 			}
 		}()
 		go func() {
@@ -134,7 +140,9 @@ func NewFromProtocol(ctx context.Context,
 				d.WaitingCacheLocal.DirtyBlocks(dirtyBlocks)
 			})
 			if err != nil && !errors.Is(err, context.Canceled) {
-				log.Debug().Err(err).Msg("HandleDirtyList returned")
+				if log != nil {
+					log.Debug().Err(err).Msg("HandleDirtyList returned")
+				}
 			}
 		}()
 		go func() {
@@ -147,7 +155,9 @@ func NewFromProtocol(ctx context.Context,
 				}
 			})
 			if err != nil && !errors.Is(err, context.Canceled) {
-				log.Debug().Err(err).Msg("HandleEvent returned")
+				if log != nil {
+					log.Debug().Err(err).Msg("HandleEvent returned")
+				}
 			}
 		}()
 	}


### PR DESCRIPTION
This fixes an issue where CPU usage is 100% after a migration