### PR TITLE
Moved S3 concurrency into per device config

### DIFF
--- a/pkg/storage/config/silo.go
+++ b/pkg/storage/config/silo.go
@@ -38,16 +38,18 @@ type SyncConfigSchema struct {
 	MinChanged  int    `hcl:"minchanged,attr"`
 	CheckPeriod string `hcl:"checkperiod,attr"`
 	Limit       int    `hcl:"limit,attr"`
+	Concurrency int    `hcl:"concurrency,attr"`
 }
 
 type SyncS3Schema struct {
-	Secure    bool              `hcl:"secure,attr"`
-	AccessKey string            `hcl:"accesskey,attr"`
-	SecretKey string            `hcl:"secretkey,attr"`
-	Endpoint  string            `hcl:"endpoint,attr"`
-	Bucket    string            `hcl:"bucket,attr"`
-	Config    *SyncConfigSchema `hcl:"config,block"`
-	AutoStart bool              `hcl:"autostart,attr"`
+	Secure          bool              `hcl:"secure,attr"`
+	AccessKey       string            `hcl:"accesskey,attr"`
+	SecretKey       string            `hcl:"secretkey,attr"`
+	Endpoint        string            `hcl:"endpoint,attr"`
+	Bucket          string            `hcl:"bucket,attr"`
+	Config          *SyncConfigSchema `hcl:"config,block"`
+	AutoStart       bool              `hcl:"autostart,attr"`
+	GrabConcurrency int               `hcl:"grabconcurrency,attr"`
 }
 
 func parseByteValue(val string) int64 {

--- a/pkg/storage/device/device.go
+++ b/pkg/storage/device/device.go
@@ -33,8 +33,6 @@ const (
 	DefaultBlockSize = 4096
 )
 
-var syncConcurrency = map[int]int{storage.BlockTypeAny: 10}
-var syncGrabConcurrency = 100
 var syncVolatilityExpiry = 10 * time.Minute
 
 type Device struct {
@@ -346,7 +344,7 @@ func NewDeviceWithLoggingMetrics(ds *config.DeviceSchema, log types.Logger, met 
 
 		// Start doing the sync...
 		syncer := migrator.NewSyncer(ctx, &migrator.SyncConfig{
-			Concurrency:      syncConcurrency,
+			Concurrency:      map[int]int{storage.BlockTypeAny: ds.Sync.Config.Concurrency},
 			Logger:           log,
 			Name:             ds.Name,
 			Integrity:        false,
@@ -389,7 +387,7 @@ func NewDeviceWithLoggingMetrics(ds *config.DeviceSchema, log types.Logger, met 
 
 				var wg sync.WaitGroup
 
-				concurrency := make(chan bool, syncGrabConcurrency)
+				concurrency := make(chan bool, ds.Sync.GrabConcurrency)
 
 				// Pull these blocks in parallel
 				for _, as := range startConfig.AlternateSources {

--- a/pkg/storage/device/device_sync_test.go
+++ b/pkg/storage/device/device_sync_test.go
@@ -36,6 +36,7 @@ func TestDeviceSync(t *testing.T) {
 			secretkey = "silosilo"
 			endpoint = "%s"
 			bucket = "silosilo"
+			grabconcurrency = 10
 			config {
 				onlydirty = true
 				blockshift = 2
@@ -43,6 +44,7 @@ func TestDeviceSync(t *testing.T) {
 				minchanged = 4
 				limit = 256
 				checkperiod = "100ms"
+				concurrency = 10
 			}
 		}
 	}
@@ -148,6 +150,7 @@ func TestDeviceSyncClose(t *testing.T) {
 			secretkey = "silosilo"
 			endpoint = "%s"
 			bucket = "silosilo"
+			grabconcurrency = 10
 			config {
 				onlydirty = true
 				blockshift = 2
@@ -155,6 +158,7 @@ func TestDeviceSyncClose(t *testing.T) {
 				minchanged = 4
 				limit = 256
 				checkperiod = "100ms"
+				concurrency = 10
 			}
 		}
 	}

--- a/pkg/storage/migrator/migrator_s3_assisted_test.go
+++ b/pkg/storage/migrator/migrator_s3_assisted_test.go
@@ -40,6 +40,7 @@ func setupDevices(t *testing.T, size int, blockSize int) (storage.Provider, stor
 			secretkey = "silosilo"
 			endpoint = "%s"
 			bucket = "silosilo"
+			grabconcurrency = 10
 			config {
 			    onlydirty = true
 				blockshift = 2
@@ -47,6 +48,7 @@ func setupDevices(t *testing.T, size int, blockSize int) (storage.Provider, stor
 				minchanged = 4
 				limit = 8
 				checkperiod = "1s"
+				concurrency = 10
 			}
 		}
 	}
@@ -65,6 +67,7 @@ func setupDevices(t *testing.T, size int, blockSize int) (storage.Provider, stor
 			secretkey = "silosilo"
 			endpoint = "%s"
 			bucket = "silosilo"
+			grabconcurrency = 10
 			config {
 			    onlydirty = true
 				blockshift = 2
@@ -72,6 +75,7 @@ func setupDevices(t *testing.T, size int, blockSize int) (storage.Provider, stor
 				minchanged = 4
 				limit = 8
 				checkperiod = "1s"
+				concurrency = 10
 			}
 		}
 	}


### PR DESCRIPTION
This moves the concurrency settings for S3 grab into per device configs