### PR TITLE
Jamesmoore/arch 259 silo cow migration improvements

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -134,6 +134,10 @@ func runConnect(_ *cobra.Command, _ []string) {
 
 	dg, err = devicegroup.NewFromProtocol(protoCtx, pro, tweak, nil, nil, log, siloMetrics)
 
+	if err != nil {
+		panic(err)
+	}
+
 	for _, d := range dg.GetDeviceSchema() {
 		expName := dg.GetExposedDeviceByName(d.Name)
 		if expName != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -40,6 +40,7 @@ var serveContinuous bool
 
 var serveMetrics string
 var serveDebug bool
+var serveConcurrency int
 
 func init() {
 	rootCmd.AddCommand(cmdServe)
@@ -48,6 +49,7 @@ func init() {
 	cmdServe.Flags().BoolVarP(&serveDebug, "debug", "d", false, "Debug logging (trace)")
 	cmdServe.Flags().StringVarP(&serveMetrics, "metrics", "m", "", "Prom metrics address")
 	cmdServe.Flags().BoolVarP(&serveContinuous, "continuous", "C", false, "Continuous sync")
+	cmdServe.Flags().IntVarP(&serveConcurrency, "concurrency", "x", 100, "Max total concurrency")
 }
 
 func runServe(_ *cobra.Command, _ []string) {
@@ -144,7 +146,7 @@ func runServe(_ *cobra.Command, _ []string) {
 			panic(err)
 		}
 
-		err = dg.MigrateAll(1000, func(ps map[string]*migrator.MigrationProgress) {
+		err = dg.MigrateAll(serveConcurrency, func(ps map[string]*migrator.MigrationProgress) {
 			for name, p := range ps {
 				fmt.Printf("[%s] Progress Moved: %d/%d %.2f%% Clean: %d/%d %.2f%% InProgress: %d\n",
 					name, p.MigratedBlocks, p.TotalBlocks, p.MigratedBlocksPerc,

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -311,7 +311,7 @@ func syncMigrateS3(_ uint32, name string,
 			mig.SetMigratedBlock(b)
 		}
 
-		sinfo.tracker.TrackAt(0, int64(sinfo.tracker.Size()))
+		sinfo.tracker.TrackAt(int64(sinfo.tracker.Size()), 0)
 	} else {
 		fmt.Printf("Doing migration...\n")
 

--- a/pkg/storage/devicegroup/device_group_from.go
+++ b/pkg/storage/devicegroup/device_group_from.go
@@ -104,13 +104,6 @@ func NewFromProtocol(ctx context.Context,
 		d.EventHandler = eventHandler
 
 		destStorageFactory := func(_ *packets.DevInfo) storage.Provider {
-			/*
-				d.WaitingCacheLocal, d.WaitingCacheRemote = waitingcache.NewWaitingCacheWithLogger(d.Prov, int(di.BlockSize), dg.log)
-
-				if d.Exp != nil {
-					d.Exp.SetProvider(d.WaitingCacheLocal)
-				}
-			*/
 			return d.WaitingCacheRemote
 		}
 

--- a/pkg/storage/devicegroup/device_group_to.go
+++ b/pkg/storage/devicegroup/device_group_to.go
@@ -289,7 +289,7 @@ func (dg *DeviceGroup) MigrateAll(maxConcurrency int, progressHandler func(p map
 				alreadyBlocks = append(alreadyBlocks, uint32(b))
 			}
 
-			err := d.To.SendYouAlreadyHave(uint64(d.BlockSize), alreadyBlocks)
+			err := d.To.SendYouAlreadyHave(d.BlockSize, alreadyBlocks)
 			if err != nil {
 				errs <- err
 			} else {

--- a/pkg/storage/devicegroup/device_group_to.go
+++ b/pkg/storage/devicegroup/device_group_to.go
@@ -363,6 +363,7 @@ func (dg *DeviceGroup) MigrateDirty(hooks *MigrateDirtyHooks) error {
 					cont, err := hooks.PostGetDirty(d.Schema.Name, blocks)
 					if err != nil {
 						errs <- err
+						return
 					}
 					if !cont {
 						break

--- a/pkg/storage/devicegroup/device_group_to.go
+++ b/pkg/storage/devicegroup/device_group_to.go
@@ -148,6 +148,22 @@ func (dg *DeviceGroup) MigrateAll(maxConcurrency int, progressHandler func(p map
 		}
 	}
 
+	// Check if the devices are actually all here?
+	for _, d := range dg.devices {
+		if d.WaitingCacheLocal != nil {
+			wcMetrics := d.WaitingCacheLocal.GetMetrics()
+			if wcMetrics.AvailableRemote < uint64(d.NumBlocks) {
+				if dg.log != nil {
+					dg.log.Warn().
+						Str("name", d.Schema.Name).
+						Uint64("availableRemoteBlocks", wcMetrics.AvailableRemote).
+						Uint64("numBlocks", uint64(d.NumBlocks)).
+						Msg("migrating away a possibly incomplete source")
+				}
+			}
+		}
+	}
+
 	ctime := time.Now()
 
 	if dg.log != nil {

--- a/pkg/storage/dirtytracker/dirty_tracker.go
+++ b/pkg/storage/dirtytracker/dirty_tracker.go
@@ -149,6 +149,7 @@ func (dt *DirtyTracker) trackArea(length int64, offset int64) {
 /**
  * Ask downstream if there are blocks that aren't required for a migration.
  * Typically these would be a base overlay, but could be something else.
+ * As well as returning the blocks, this call will update the dirty tracker as if the blocks had been read (To start tracking dirty changes)
  */
 func (dtr *Remote) GetUnrequiredBlocks() []uint {
 	// Make sure no writes get through...

--- a/pkg/storage/dirtytracker/dirty_tracker.go
+++ b/pkg/storage/dirtytracker/dirty_tracker.go
@@ -150,7 +150,7 @@ func (dt *DirtyTracker) trackArea(length int64, offset int64) {
  * Start tracking at the given offset and length
  *
  */
-func (dtr *Remote) TrackAt(offset int64, length int64) {
+func (dtr *Remote) TrackAt(length int64, offset int64) {
 	dtr.dt.trackArea(length, offset)
 }
 

--- a/pkg/storage/dirtytracker/dirty_tracker.go
+++ b/pkg/storage/dirtytracker/dirty_tracker.go
@@ -155,6 +155,14 @@ func (dtr *Remote) TrackAt(offset int64, length int64) {
 }
 
 /**
+ * Check which blocks are being tracked
+ *
+ */
+func (dtr *Remote) GetTrackedBlocks() []uint {
+	return dtr.dt.tracking.Collect(0, dtr.dt.tracking.Length())
+}
+
+/**
  * Get a quick measure of how many blocks are currently dirty
  *
  */

--- a/pkg/storage/dirtytracker/dirty_tracker.go
+++ b/pkg/storage/dirtytracker/dirty_tracker.go
@@ -146,6 +146,14 @@ func (dt *DirtyTracker) trackArea(length int64, offset int64) {
 	dt.tracking.SetBits(bStart, bEnd)
 }
 
+func (dtr *Remote) LockWrites() {
+	dtr.dt.writeLock.Lock()
+}
+
+func (dtr *Remote) UnlockWrites() {
+	dtr.dt.writeLock.Unlock()
+}
+
 /**
  * Start tracking at the given offset and length
  *

--- a/pkg/storage/metrics/prometheus/prometheus.go
+++ b/pkg/storage/metrics/prometheus/prometheus.go
@@ -128,6 +128,8 @@ type Metrics struct {
 	toProtocolSentWriteAtBytes         *prometheus.GaugeVec
 	toProtocolSentWriteAtWithMap       *prometheus.GaugeVec
 	toProtocolSentRemoveFromMap        *prometheus.GaugeVec
+	toProtocolSentYouAlreadyHave       *prometheus.GaugeVec
+	toProtocolSentYouAlreadyHaveBytes  *prometheus.GaugeVec
 	toProtocolRecvNeedAt               *prometheus.GaugeVec
 	toProtocolRecvDontNeedAt           *prometheus.GaugeVec
 
@@ -281,6 +283,10 @@ func New(reg prometheus.Registerer, config *MetricsConfig) *Metrics {
 			Namespace: config.Namespace, Subsystem: config.SubToProtocol, Name: "sent_write_at_with_map", Help: "sentWriteAtWithMap"}, []string{"device"}),
 		toProtocolSentRemoveFromMap: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: config.Namespace, Subsystem: config.SubToProtocol, Name: "sent_remove_from_map", Help: "sentRemoveFromMap"}, []string{"device"}),
+		toProtocolSentYouAlreadyHave: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: config.Namespace, Subsystem: config.SubToProtocol, Name: "sent_you_already_have", Help: "sentYouAlreadyHave"}, []string{"device"}),
+		toProtocolSentYouAlreadyHaveBytes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: config.Namespace, Subsystem: config.SubToProtocol, Name: "sent_you_already_have_bytes", Help: "sentYouAlreadyHaveBytes"}, []string{"device"}),
 		toProtocolRecvNeedAt: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: config.Namespace, Subsystem: config.SubToProtocol, Name: "recv_need_at", Help: "recvNeedAt"}, []string{"device"}),
 		toProtocolRecvDontNeedAt: prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -434,7 +440,8 @@ func New(reg prometheus.Registerer, config *MetricsConfig) *Metrics {
 		met.toProtocolSentDirtyList, met.toProtocolSentReadAt, met.toProtocolSentWriteAtHash, met.toProtocolSentWriteAtHashBytes,
 		met.toProtocolSentWriteAtComp, met.toProtocolSentWriteAtCompBytes, met.toProtocolSentWriteAtCompDataBytes,
 		met.toProtocolSentWriteAt, met.toProtocolSentWriteAtBytes, met.toProtocolSentWriteAtWithMap,
-		met.toProtocolSentRemoveFromMap, met.toProtocolRecvNeedAt, met.toProtocolRecvDontNeedAt,
+		met.toProtocolSentRemoveFromMap, met.toProtocolSentYouAlreadyHave, met.toProtocolSentYouAlreadyHaveBytes,
+		met.toProtocolRecvNeedAt, met.toProtocolRecvDontNeedAt,
 	)
 
 	reg.MustRegister(met.fromProtocolRecvEvents, met.fromProtocolRecvHashes, met.fromProtocolRecvDevInfo,
@@ -591,6 +598,8 @@ func (m *Metrics) AddToProtocol(name string, proto *protocol.ToProtocol) {
 		m.toProtocolSentWriteAtBytes.WithLabelValues(name).Set(float64(met.SentWriteAtBytes))
 		m.toProtocolSentWriteAtWithMap.WithLabelValues(name).Set(float64(met.SentWriteAtWithMap))
 		m.toProtocolSentRemoveFromMap.WithLabelValues(name).Set(float64(met.SentRemoveFromMap))
+		m.toProtocolSentYouAlreadyHave.WithLabelValues(name).Set(float64(met.SentYouAlreadyHave))
+		m.toProtocolSentYouAlreadyHaveBytes.WithLabelValues(name).Set(float64(met.SentYouAlreadyHaveBytes))
 		m.toProtocolRecvNeedAt.WithLabelValues(name).Set(float64(met.RecvNeedAt))
 		m.toProtocolRecvDontNeedAt.WithLabelValues(name).Set(float64(met.RecvDontNeedAt))
 	})

--- a/pkg/storage/migrator/cow_test.go
+++ b/pkg/storage/migrator/cow_test.go
@@ -71,7 +71,7 @@ func setupCowDevice(t *testing.T) (storage.Provider, int, []byte) {
 	})
 
 	// Write some changes to the device...
-	for _, offset := range []int64{0, 10 * 1024, 100 * 1024} {
+	for _, offset := range []int64{0, 10 * 1024, 400000, 701902} {
 		chgData := make([]byte, 4*1024)
 		_, err = crand.Read(chgData)
 		assert.NoError(t, err)
@@ -119,18 +119,22 @@ func TestCowGetBlocks(t *testing.T) {
 	assert.Equal(t, 1, len(erd))
 
 	// A list of blocks
-	blocks := erd[0].([]int)
+	blocks, ok := erd[0].([]uint)
+	assert.True(t, ok)
 
-	for _, b := range blocks {
-		fmt.Printf("BLOCK %d\n", b)
-	}
+	assert.Equal(t, []uint{0, 6, 10}, blocks)
 
 	// Check they're being tracked now
 	tracking := trackRemote.GetTrackedBlocks()
 
-	for _, b := range tracking {
-		fmt.Printf("TRACKING %d\n", b)
+	expected := make([]uint, 0)
+	for v := 0; v < 800; v++ {
+		if v != 0 && v != 6 && v != 10 {
+			expected = append(expected, uint(v))
+		}
 	}
+
+	assert.Equal(t, expected, tracking)
 }
 
 func TestMigratorCow(t *testing.T) {

--- a/pkg/storage/migrator/cow_test.go
+++ b/pkg/storage/migrator/cow_test.go
@@ -105,17 +105,15 @@ func TestCowGetBlocks(t *testing.T) {
 }
 
 type migratorCowTest struct {
-	name           string
-	sharedBase     bool
-	noCowMigration bool
+	name       string
+	sharedBase bool
 }
 
 func TestMigratorCow(tt *testing.T) {
 
 	for _, v := range []migratorCowTest{
-		{name: "standard", sharedBase: false, noCowMigration: false},
-		{name: "improved", sharedBase: true, noCowMigration: false},
-		{name: "better", sharedBase: true, noCowMigration: true}, // We do things outside the migrator...
+		{name: "standard", sharedBase: false},
+		{name: "better", sharedBase: true},
 	} {
 		tt.Run(v.name, func(t *testing.T) {
 			prov, blockSize, _ := setupCowDevice(t, v.sharedBase)
@@ -190,7 +188,7 @@ func TestMigratorCow(tt *testing.T) {
 
 			migrateBlocks := numBlocks
 
-			if v.noCowMigration {
+			if v.sharedBase {
 				// With this, ONLY migrate the blocks we need... For the others, we'll send cmds manually...
 				unrequired := sourceDirtyRemote.GetUnrequiredBlocks()
 				alreadyBlocks := make([]uint32, 0)
@@ -212,8 +210,6 @@ func TestMigratorCow(tt *testing.T) {
 				conf)
 
 			assert.NoError(t, err)
-
-			mig.NoCowMigration = v.noCowMigration
 
 			err = mig.Migrate(migrateBlocks)
 			assert.NoError(t, err)

--- a/pkg/storage/migrator/cow_test.go
+++ b/pkg/storage/migrator/cow_test.go
@@ -196,17 +196,11 @@ func TestMigratorCow(tt *testing.T) {
 				alreadyBlocks := make([]uint32, 0)
 				for _, b := range unrequired {
 					orderer.Remove(int(b))
-					// Send the data here...
-					// We need less blocks here...
 					migrateBlocks--
 					alreadyBlocks = append(alreadyBlocks, uint32(b))
 				}
 
-				data := packets.EncodeYouAlreadyHave(uint64(blockSize), alreadyBlocks)
-				id, err := prSource.SendPacket(17, protocol.IDPickAny, data, protocol.UrgencyNormal)
-				assert.NoError(t, err)
-				// Wait for ACK
-				_, err = prSource.WaitForPacket(17, id)
+				err = destination.SendYouAlreadyHave(uint64(blockSize), alreadyBlocks)
 				assert.NoError(t, err)
 			}
 

--- a/pkg/storage/migrator/cow_test.go
+++ b/pkg/storage/migrator/cow_test.go
@@ -108,6 +108,31 @@ func TestCowGetBase(t *testing.T) {
 
 }
 
+func TestCowGetBlocks(t *testing.T) {
+	prov, _, _ := setupCowDevice(t)
+
+	// Setup a dirty tracker
+	_, trackRemote := dirtytracker.NewDirtyTracker(prov, 65536)
+
+	erd := storage.SendSiloEvent(prov, storage.EventTypeCowGetBlocks, trackRemote)
+	// Check it returns a list of blocks
+	assert.Equal(t, 1, len(erd))
+
+	// A list of blocks
+	blocks := erd[0].([]int)
+
+	for _, b := range blocks {
+		fmt.Printf("BLOCK %d\n", b)
+	}
+
+	// Check they're being tracked now
+	tracking := trackRemote.GetTrackedBlocks()
+
+	for _, b := range tracking {
+		fmt.Printf("TRACKING %d\n", b)
+	}
+}
+
 func TestMigratorCow(t *testing.T) {
 	prov, blockSize, _ := setupCowDevice(t)
 

--- a/pkg/storage/migrator/migrator.go
+++ b/pkg/storage/migrator/migrator.go
@@ -110,7 +110,6 @@ type Migrator struct {
 	dedupeWrites           bool
 	recentWriteAge         time.Duration
 	migrationStarted       bool
-	migrationDirtyStarted  bool
 	migrationStartTime     time.Time
 }
 

--- a/pkg/storage/migrator/migrator_test.go
+++ b/pkg/storage/migrator/migrator_test.go
@@ -864,8 +864,6 @@ func TestMigratorSimpleCowSparse(t *testing.T) {
 		orderer,
 		conf)
 
-	mig.NoCowMigration = true
-
 	assert.NoError(t, err)
 
 	err = mig.Migrate(migrateBlocks)

--- a/pkg/storage/migrator/migrator_test.go
+++ b/pkg/storage/migrator/migrator_test.go
@@ -791,14 +791,14 @@ func TestMigratorSimpleCowSparse(t *testing.T) {
 	numBlocks := (size + blockSize - 1) / blockSize
 
 	sourceStorageMem := sources.NewMemoryStorage(size)
-	overlay, err := sources.NewFileStorageSparseCreate("test_migrate_cow", uint64(size), blockSize)
+	overlay, err := sources.NewFileStorageSparseCreate("test_simple_migrate_cow", uint64(size), blockSize)
 	assert.NoError(t, err)
 	cow := modules.NewCopyOnWrite(sourceStorageMem, overlay, blockSize)
 	sourceDirtyLocal, sourceDirtyRemote := dirtytracker.NewDirtyTracker(cow, blockSize)
 	sourceStorage := modules.NewLockable(sourceDirtyLocal)
 
 	t.Cleanup(func() {
-		os.Remove("test_migrate_cow")
+		os.Remove("test_simple_migrate_cow")
 	})
 
 	// Set up some data here.

--- a/pkg/storage/migrator/sync.go
+++ b/pkg/storage/migrator/sync.go
@@ -223,7 +223,7 @@ func (s *Syncer) Sync(syncAllFirst bool, continuous bool) (*MigrationProgress, e
 			mig.SetMigratedBlock(b)
 		}
 		// Track changes for everything.
-		s.config.Tracker.TrackAt(0, int64(s.config.Tracker.Size()))
+		s.config.Tracker.TrackAt(int64(s.config.Tracker.Size()), 0)
 	}
 
 	// Now enter a loop looking for more dirty blocks to migrate...

--- a/pkg/storage/modules/copy_on_write.go
+++ b/pkg/storage/modules/copy_on_write.go
@@ -29,12 +29,7 @@ var ErrClosed = errors.New("device is closing or already closed")
 // Relay events to embedded StorageProvider
 func (i *CopyOnWrite) SendSiloEvent(eventType storage.EventType, eventData storage.EventData) []storage.EventReturnData {
 	if i.sharedBase {
-		// Something is asking for a Base provider. Respond with the source provider.
-		if eventType == storage.EventTypeBaseGet {
-			return []storage.EventReturnData{
-				i.source,
-			}
-		} else if eventType == storage.EventTypeCowGetBlocks {
+		if eventType == storage.EventTypeCowGetBlocks {
 			i.writeLock.Lock() // Just makes sure that no writes are in progress while we snapshot.
 			unrequired := i.exists.CollectZeroes(0, i.exists.Length())
 			i.writeLock.Unlock()

--- a/pkg/storage/protocol/from_protocol.go
+++ b/pkg/storage/protocol/from_protocol.go
@@ -44,46 +44,48 @@ type FromProtocol struct {
 	completeFuncLock sync.Mutex
 
 	// metrics
-	metricRecvEvents         uint64
-	metricRecvHashes         uint64
-	metricRecvDevInfo        uint64
-	metricRecvAltSources     uint64
-	metricRecvReadAt         uint64
-	metricRecvWriteAtHash    uint64
-	metricRecvWriteAtComp    uint64
-	metricRecvWriteAt        uint64
-	metricRecvWriteAtWithMap uint64
-	metricRecvRemoveFromMap  uint64
-	metricRecvRemoveDev      uint64
-	metricRecvDirtyList      uint64
-	metricSentNeedAt         uint64
-	metricSentDontNeedAt     uint64
+	metricRecvEvents                uint64
+	metricRecvHashes                uint64
+	metricRecvDevInfo               uint64
+	metricRecvAltSources            uint64
+	metricRecvReadAt                uint64
+	metricRecvWriteAtHash           uint64
+	metricRecvWriteAtYouAlreadyHave uint64
+	metricRecvWriteAtComp           uint64
+	metricRecvWriteAt               uint64
+	metricRecvWriteAtWithMap        uint64
+	metricRecvRemoveFromMap         uint64
+	metricRecvRemoveDev             uint64
+	metricRecvDirtyList             uint64
+	metricSentNeedAt                uint64
+	metricSentDontNeedAt            uint64
 }
 
 type FromProtocolMetrics struct {
-	RecvEvents              uint64
-	RecvHashes              uint64
-	RecvDevInfo             uint64
-	RecvAltSources          uint64
-	RecvReadAt              uint64
-	RecvWriteAtHash         uint64
-	RecvWriteAtComp         uint64
-	RecvWriteAt             uint64
-	RecvWriteAtWithMap      uint64
-	RecvRemoveFromMap       uint64
-	RecvRemoveDev           uint64
-	RecvDirtyList           uint64
-	SentNeedAt              uint64
-	SentDontNeedAt          uint64
-	WritesAllowedP2P        uint64
-	WritesBlockedP2P        uint64
-	WritesAllowedAltSources uint64
-	WritesBlockedAltSources uint64
-	NumBlocks               uint64
-	AvailableP2P            []uint
-	DuplicateP2P            []uint
-	AvailableAltSources     []uint
-	DeviceName              string
+	RecvEvents                uint64
+	RecvHashes                uint64
+	RecvDevInfo               uint64
+	RecvAltSources            uint64
+	RecvReadAt                uint64
+	RecvWriteAtHash           uint64
+	RecvWriteAtYouAlreadyHave uint64
+	RecvWriteAtComp           uint64
+	RecvWriteAt               uint64
+	RecvWriteAtWithMap        uint64
+	RecvRemoveFromMap         uint64
+	RecvRemoveDev             uint64
+	RecvDirtyList             uint64
+	SentNeedAt                uint64
+	SentDontNeedAt            uint64
+	WritesAllowedP2P          uint64
+	WritesBlockedP2P          uint64
+	WritesAllowedAltSources   uint64
+	WritesBlockedAltSources   uint64
+	NumBlocks                 uint64
+	AvailableP2P              []uint
+	DuplicateP2P              []uint
+	AvailableAltSources       []uint
+	DeviceName                string
 }
 
 func NewFromProtocol(ctx context.Context, dev uint32, provFactory func(*packets.DevInfo) storage.Provider, protocol Protocol) *FromProtocol {
@@ -105,26 +107,27 @@ func NewFromProtocolWithSyncBehaviour(ctx context.Context, dev uint32, provFacto
 
 func (fp *FromProtocol) GetMetrics() *FromProtocolMetrics {
 	fpm := &FromProtocolMetrics{
-		RecvEvents:              atomic.LoadUint64(&fp.metricRecvEvents),
-		RecvHashes:              atomic.LoadUint64(&fp.metricRecvHashes),
-		RecvDevInfo:             atomic.LoadUint64(&fp.metricRecvDevInfo),
-		RecvAltSources:          atomic.LoadUint64(&fp.metricRecvAltSources),
-		RecvReadAt:              atomic.LoadUint64(&fp.metricRecvReadAt),
-		RecvWriteAtHash:         atomic.LoadUint64(&fp.metricRecvWriteAtHash),
-		RecvWriteAtComp:         atomic.LoadUint64(&fp.metricRecvWriteAtComp),
-		RecvWriteAt:             atomic.LoadUint64(&fp.metricRecvWriteAt),
-		RecvWriteAtWithMap:      atomic.LoadUint64(&fp.metricRecvWriteAtWithMap),
-		RecvRemoveFromMap:       atomic.LoadUint64(&fp.metricRecvRemoveFromMap),
-		RecvRemoveDev:           atomic.LoadUint64(&fp.metricRecvRemoveDev),
-		RecvDirtyList:           atomic.LoadUint64(&fp.metricRecvDirtyList),
-		SentNeedAt:              atomic.LoadUint64(&fp.metricSentNeedAt),
-		SentDontNeedAt:          atomic.LoadUint64(&fp.metricSentDontNeedAt),
-		WritesAllowedP2P:        0,
-		WritesBlockedP2P:        0,
-		WritesAllowedAltSources: 0,
-		WritesBlockedAltSources: 0,
-		NumBlocks:               0,
-		DeviceName:              "",
+		RecvEvents:                atomic.LoadUint64(&fp.metricRecvEvents),
+		RecvHashes:                atomic.LoadUint64(&fp.metricRecvHashes),
+		RecvDevInfo:               atomic.LoadUint64(&fp.metricRecvDevInfo),
+		RecvAltSources:            atomic.LoadUint64(&fp.metricRecvAltSources),
+		RecvReadAt:                atomic.LoadUint64(&fp.metricRecvReadAt),
+		RecvWriteAtHash:           atomic.LoadUint64(&fp.metricRecvWriteAtHash),
+		RecvWriteAtYouAlreadyHave: atomic.LoadUint64(&fp.metricRecvWriteAtYouAlreadyHave),
+		RecvWriteAtComp:           atomic.LoadUint64(&fp.metricRecvWriteAtComp),
+		RecvWriteAt:               atomic.LoadUint64(&fp.metricRecvWriteAt),
+		RecvWriteAtWithMap:        atomic.LoadUint64(&fp.metricRecvWriteAtWithMap),
+		RecvRemoveFromMap:         atomic.LoadUint64(&fp.metricRecvRemoveFromMap),
+		RecvRemoveDev:             atomic.LoadUint64(&fp.metricRecvRemoveDev),
+		RecvDirtyList:             atomic.LoadUint64(&fp.metricRecvDirtyList),
+		SentNeedAt:                atomic.LoadUint64(&fp.metricSentNeedAt),
+		SentDontNeedAt:            atomic.LoadUint64(&fp.metricSentDontNeedAt),
+		WritesAllowedP2P:          0,
+		WritesBlockedP2P:          0,
+		WritesAllowedAltSources:   0,
+		WritesBlockedAltSources:   0,
+		NumBlocks:                 0,
+		DeviceName:                "",
 	}
 
 	fp.initLock.Lock()
@@ -393,8 +396,8 @@ func (fp *FromProtocol) HandleWriteAt() error {
 
 		if len(data) > 1 && data[1] == packets.WriteAtHash {
 			// It could be a WriteAtHash command...
-			offset, length, _, loc, errWriteAtHash := packets.DecodeWriteAtHash(data)
-			if errWriteAtHash != nil {
+			offset, length, _, loc, err := packets.DecodeWriteAtHash(data)
+			if err != nil {
 				return err
 			}
 
@@ -411,6 +414,31 @@ func (fp *FromProtocol) HandleWriteAt() error {
 
 			// Tell anything down the chain about this 'write'
 			if loc == packets.DataLocationBaseImage {
+				// Is provP2P the right thing here? Or should it be prov... or does it matter...
+				storage.SendSiloEvent(fp.provP2P, storage.EventTypeAvailable, storage.EventData([]int64{offset, length}))
+			}
+		} else if len(data) > 1 && data[1] == packets.WriteAtYouAlreadyHave {
+			// It could be a WriteAtYouAlreadyHave command...
+			blockSize, blocks, err := packets.DecodeYouAlreadyHave(data)
+			if err != nil {
+				return err
+			}
+
+			atomic.AddUint64(&fp.metricRecvWriteAtYouAlreadyHave, 1)
+
+			// Ack
+			war := &packets.WriteAtResponse{
+				Error: nil,
+				Bytes: int(uint64(len(blocks)) * blockSize),
+			}
+			_, err = fp.protocol.SendPacket(fp.dev, id, packets.EncodeWriteAtResponse(war), UrgencyNormal)
+			if err != nil {
+				return err
+			}
+
+			for _, b := range blocks {
+				offset := int64(uint64(b) * blockSize)
+				length := int64(blockSize)
 				// Is provP2P the right thing here? Or should it be prov... or does it matter...
 				storage.SendSiloEvent(fp.provP2P, storage.EventTypeAvailable, storage.EventData([]int64{offset, length}))
 			}

--- a/pkg/storage/protocol/from_protocol.go
+++ b/pkg/storage/protocol/from_protocol.go
@@ -396,7 +396,7 @@ func (fp *FromProtocol) HandleWriteAt() error {
 
 		if len(data) > 1 && data[1] == packets.WriteAtHash {
 			// It could be a WriteAtHash command...
-			offset, length, _, loc, err := packets.DecodeWriteAtHash(data)
+			_, length, _, _, err := packets.DecodeWriteAtHash(data)
 			if err != nil {
 				return err
 			}
@@ -410,12 +410,6 @@ func (fp *FromProtocol) HandleWriteAt() error {
 			_, err = fp.protocol.SendPacket(fp.dev, id, packets.EncodeWriteAtResponse(war), UrgencyNormal)
 			if err != nil {
 				return err
-			}
-
-			// Tell anything down the chain about this 'write'
-			if loc == packets.DataLocationBaseImage {
-				// Is provP2P the right thing here? Or should it be prov... or does it matter...
-				storage.SendSiloEvent(fp.provP2P, storage.EventTypeAvailable, storage.EventData([]int64{offset, length}))
 			}
 		} else if len(data) > 1 && data[1] == packets.WriteAtYouAlreadyHave {
 			// It could be a WriteAtYouAlreadyHave command...

--- a/pkg/storage/protocol/packets/packet_test.go
+++ b/pkg/storage/protocol/packets/packet_test.go
@@ -397,3 +397,18 @@ func TestDeviceGroupInfo(t *testing.T) {
 		assert.Equal(t, di.Schema, di2.Schema)
 	}
 }
+
+func TestYouAlreadyHave(t *testing.T) {
+
+	blocks := []uint32{0, 66, 180, 3}
+	blockSize := uint64(500000)
+
+	b := EncodeYouAlreadyHave(blockSize, blocks)
+
+	blockSize2, blocks2, err := DecodeYouAlreadyHave(b)
+	assert.NoError(t, err)
+	assert.Equal(t, len(blocks), len(blocks2))
+	assert.Equal(t, blockSize, blockSize2)
+	assert.Equal(t, blocks, blocks2)
+
+}

--- a/pkg/storage/protocol/packets/write_at.go
+++ b/pkg/storage/protocol/packets/write_at.go
@@ -7,6 +7,7 @@ import (
 const WriteAtData = 0
 const WriteAtHash = 1
 const WriteAtCompRLE = 2
+const WriteAtYouAlreadyHave = 3
 
 func EncodeWriteAt(offset int64, data []byte) []byte {
 	buff := make([]byte, 2+8+len(data))

--- a/pkg/storage/protocol/packets/you_already_have.go
+++ b/pkg/storage/protocol/packets/you_already_have.go
@@ -1,0 +1,50 @@
+package packets
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+type YouAlreadyHave struct {
+	BlockSize uint64
+	Blocks    []uint32
+}
+
+func EncodeYouAlreadyHave(blockSize uint64, blocks []uint32) []byte {
+	var buff bytes.Buffer
+
+	head := make([]byte, 1+1+8+4)
+	head[0] = CommandWriteAt
+	head[1] = WriteAtYouAlreadyHave
+	binary.LittleEndian.PutUint64(head[2:], blockSize)
+	binary.LittleEndian.PutUint32(head[10:], uint32(len(blocks)))
+
+	buff.Write(head)
+
+	v := make([]byte, 4)
+	for _, b := range blocks {
+		binary.LittleEndian.PutUint32(v, b)
+		buff.Write(v)
+	}
+
+	return buff.Bytes()
+}
+
+func DecodeYouAlreadyHave(buff []byte) (uint64, []uint32, error) {
+	if buff == nil || len(buff) < 1+1+8+4 || buff[0] != CommandWriteAt || buff[1] != WriteAtYouAlreadyHave {
+		return 0, nil, ErrInvalidPacket
+	}
+
+	blockSize := binary.LittleEndian.Uint64(buff[2:])
+	l := int(binary.LittleEndian.Uint32(buff[10:]))
+
+	blocks := make([]uint32, 0)
+	ptr := 1 + 1 + 8 + 4
+	for a := 0; a < l; a++ {
+		b := binary.LittleEndian.Uint32(buff[ptr:])
+		blocks = append(blocks, b)
+		ptr += 4
+	}
+
+	return blockSize, blocks, nil
+}

--- a/pkg/storage/protocol/to_protocol.go
+++ b/pkg/storage/protocol/to_protocol.go
@@ -33,6 +33,8 @@ type ToProtocol struct {
 	metricSentWriteAtBytes         uint64
 	metricSentWriteAtWithMap       uint64
 	metricSentRemoveFromMap        uint64
+	metricSentYouAlreadyHave       uint64
+	metricSentYouAlreadyHaveBytes  uint64
 	metricRecvNeedAt               uint64
 	metricRecvDontNeedAt           uint64
 }
@@ -62,6 +64,8 @@ type ToProtocolMetrics struct {
 	SentWriteAtBytes         uint64
 	SentWriteAtWithMap       uint64
 	SentRemoveFromMap        uint64
+	SentYouAlreadyHave       uint64
+	SentYouAlreadyHaveBytes  uint64
 	RecvNeedAt               uint64
 	RecvDontNeedAt           uint64
 }
@@ -84,6 +88,8 @@ func (i *ToProtocol) GetMetrics() *ToProtocolMetrics {
 		SentWriteAtBytes:         atomic.LoadUint64(&i.metricSentWriteAtBytes),
 		SentWriteAtWithMap:       atomic.LoadUint64(&i.metricSentWriteAtWithMap),
 		SentRemoveFromMap:        atomic.LoadUint64(&i.metricSentRemoveFromMap),
+		SentYouAlreadyHave:       atomic.LoadUint64(&i.metricSentYouAlreadyHave),
+		SentYouAlreadyHaveBytes:  atomic.LoadUint64(&i.metricSentYouAlreadyHaveBytes),
 		RecvNeedAt:               atomic.LoadUint64(&i.metricRecvNeedAt),
 		RecvDontNeedAt:           atomic.LoadUint64(&i.metricRecvDontNeedAt),
 	}
@@ -108,6 +114,11 @@ func (i *ToProtocol) SendYouAlreadyHave(blockSize uint64, alreadyBlocks []uint32
 	}
 	// Wait for ACK
 	_, err = i.protocol.WaitForPacket(i.dev, id)
+	if err == nil {
+		atomic.AddUint64(&i.metricSentYouAlreadyHave, 1)
+		atomic.AddUint64(&i.metricSentYouAlreadyHaveBytes, uint64(len(alreadyBlocks))*blockSize)
+
+	}
 	return err
 }
 

--- a/pkg/storage/protocol/to_protocol.go
+++ b/pkg/storage/protocol/to_protocol.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
-	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -111,10 +110,8 @@ func (i *ToProtocol) SendSiloEvent(eventType storage.EventType, eventData storag
 		i.baseImageLock.Lock()
 		blocks, ok := eventData.(map[uint]uint)
 		if ok {
-			fmt.Printf("-Setting baseBlocks to %v\n", blocks)
 			i.baseBlocks = blocks
 		} else {
-			fmt.Printf("-Setting baseBlocks to nil\n")
 			i.baseBlocks = nil
 		}
 		i.baseImageLock.Unlock()
@@ -278,7 +275,6 @@ func (i *ToProtocol) WriteAt(buffer []byte, offset int64) (int, error) {
 			}
 		}
 	} else if len(baseBlocks) > 0 {
-		fmt.Printf("Using baseBlocks\n")
 		if baseBlocks[uint(offset)] == uint(len(buffer)) {
 			// The data is exactly the same as our "base" image. Send it as WriteAtHash commands.
 			hash := make([]byte, sha256.Size) // Empty for now

--- a/pkg/storage/protocol/to_protocol.go
+++ b/pkg/storage/protocol/to_protocol.go
@@ -113,6 +113,17 @@ func (i *ToProtocol) SendSiloEvent(eventType storage.EventType, eventData storag
 	return nil
 }
 
+func (i *ToProtocol) SendYouAlreadyHave(blockSize uint64, alreadyBlocks []uint32) error {
+	data := packets.EncodeYouAlreadyHave(blockSize, alreadyBlocks)
+	id, err := i.protocol.SendPacket(i.dev, IDPickAny, data, UrgencyUrgent)
+	if err != nil {
+		return err
+	}
+	// Wait for ACK
+	_, err = i.protocol.WaitForPacket(i.dev, id)
+	return err
+}
+
 func (i *ToProtocol) SetCompression(compressed bool) {
 	i.compressedWrites.Store(compressed)
 }

--- a/pkg/storage/protocol/to_protocol.go
+++ b/pkg/storage/protocol/to_protocol.go
@@ -271,8 +271,6 @@ func (i *ToProtocol) WriteAt(buffer []byte, offset int64) (int, error) {
 		}
 	} else if baseBlocks != nil {
 		if baseBlocks[uint(offset)] == uint(len(buffer)) {
-			// It's part of the overlay. Send it as usual.
-		} else {
 			// The data is exactly the same as our "base" image. Send it as WriteAtHash commands.
 			hash := make([]byte, sha256.Size) // Empty for now
 			data := packets.EncodeWriteAtHash(offset, int64(len(buffer)), hash, packets.DataLocationBaseImage)

--- a/pkg/storage/protocol/to_protocol.go
+++ b/pkg/storage/protocol/to_protocol.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
-	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -111,7 +110,6 @@ func (i *ToProtocol) SendSiloEvent(eventType storage.EventType, eventData storag
 		i.baseImageLock.Lock()
 		i.baseBlocks = eventData.(map[uint]uint)
 		i.baseImageLock.Unlock()
-		fmt.Printf("CowSetBlocks in toProtocol %v\n", eventData)
 	}
 	return nil
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -26,6 +26,8 @@ type LockableProvider interface {
 
 type TrackingProvider interface {
 	Provider
+	LockWrites()
+	UnlockWrites()
 	TrackAt(length int64, offset int64)
 	Sync() *util.Bitfield
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -26,6 +26,7 @@ type LockableProvider interface {
 
 type TrackingProvider interface {
 	Provider
+	TrackAt(length int64, offset int64)
 	Sync() *util.Bitfield
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -26,8 +26,7 @@ type LockableProvider interface {
 
 type TrackingProvider interface {
 	Provider
-	LockWrites()
-	UnlockWrites()
+	GetUnrequiredBlocks() []uint
 	TrackAt(length int64, offset int64)
 	Sync() *util.Bitfield
 }

--- a/pkg/storage/storage_events.go
+++ b/pkg/storage/storage_events.go
@@ -8,6 +8,7 @@ const EventTypeBaseGet = EventType("base.get")
 const EventTypeAvailable = EventType("available")
 
 const EventTypeCowGetBlocks = EventType("cow.get.blocks")
+const EventTypeCowSetBlocks = EventType("cow.set.blocks")
 
 const EventSyncStop = EventType("sync.stop")
 const EventSyncStart = EventType("sync.start")

--- a/pkg/storage/storage_events.go
+++ b/pkg/storage/storage_events.go
@@ -3,10 +3,8 @@ package storage
 import "sync"
 
 const EventTypeSources = EventType("sources")
-const EventTypeAvailable = EventType("available")
-
 const EventTypeCowGetBlocks = EventType("cow.get.blocks")
-const EventTypeCowSetBlocks = EventType("cow.set.blocks")
+const EventTypeAvailable = EventType("available")
 
 const EventSyncStop = EventType("sync.stop")
 const EventSyncStart = EventType("sync.start")

--- a/pkg/storage/storage_events.go
+++ b/pkg/storage/storage_events.go
@@ -3,8 +3,6 @@ package storage
 import "sync"
 
 const EventTypeSources = EventType("sources")
-const EventTypeBaseSet = EventType("base.set")
-const EventTypeBaseGet = EventType("base.get")
 const EventTypeAvailable = EventType("available")
 
 const EventTypeCowGetBlocks = EventType("cow.get.blocks")

--- a/pkg/storage/storage_events.go
+++ b/pkg/storage/storage_events.go
@@ -7,6 +7,8 @@ const EventTypeBaseSet = EventType("base.set")
 const EventTypeBaseGet = EventType("base.get")
 const EventTypeAvailable = EventType("available")
 
+const EventTypeCowGetBlocks = EventType("cow.get.blocks")
+
 const EventSyncStop = EventType("sync.stop")
 const EventSyncStart = EventType("sync.start")
 const EventSyncStatus = EventType("sync.status")

--- a/pkg/storage/util/bitfield.go
+++ b/pkg/storage/util/bitfield.go
@@ -383,6 +383,39 @@ func (bf *Bitfield) Collect(start uint, end uint) []uint {
 }
 
 /**
+ * Collect the positions of all 0 bits
+ *
+ */
+func (bf *Bitfield) CollectZeroes(start uint, end uint) []uint {
+	positions := make([]uint, 0)
+	p := start >> 6
+	i := uint64(1 << (start & 63))
+	n := start
+	if n < end {
+		val := atomic.LoadUint64(&bf.data[p])
+		for {
+			// Check the bit
+			if (val & i) == 0 {
+				positions = append(positions, n)
+			}
+
+			// Move along one...
+			n++
+			if n == end {
+				break
+			}
+			i <<= 1
+			if i == 0 {
+				i = 1
+				p++
+				val = atomic.LoadUint64(&bf.data[p])
+			}
+		}
+	}
+	return positions
+}
+
+/**
  * Collect the first set bit, and clear it
  *
  */

--- a/pkg/storage/util/bitfield_test.go
+++ b/pkg/storage/util/bitfield_test.go
@@ -165,6 +165,18 @@ func TestBitfieldCollect(t *testing.T) {
 	assert.Equal(t, []uint{100, 101, 102, 103, 200}, c)
 }
 
+func TestBitfieldCollectZeroes(t *testing.T) {
+	bf := NewBitfield(1000)
+
+	bf.SetBits(0, 1000)
+	bf.ClearBits(100, 104)
+	bf.ClearBit(200)
+
+	c := bf.CollectZeroes(0, bf.Length())
+
+	assert.Equal(t, []uint{100, 101, 102, 103, 200}, c)
+}
+
 func TestBitfieldSetBitIfClear(t *testing.T) {
 	bf := NewBitfield(1000)
 


### PR DESCRIPTION
The original CoW Migration strategy drastically reduced the amount of data transferred, but it had some deficiencies.
1. It was still reading the entire device from disk
2. It was hashing the data, using lots of CPU

This change makes it possible to migrate CoW devices without excess disk or CPU usage.