### PR TITLE
Disable altSources on dirty blocks for now

### DIFF
--- a/pkg/storage/devicegroup/device_group_to.go
+++ b/pkg/storage/devicegroup/device_group_to.go
@@ -375,6 +375,8 @@ func (dg *DeviceGroup) MigrateDirty(hooks *MigrateDirtyHooks) error {
 		// First unlock the storage if it is locked due to a previous MigrateDirty call
 		d.Storage.Unlock()
 
+		d.To.ClearAltSources()
+
 		go func() {
 			for {
 				if hooks != nil && hooks.PreGetDirty != nil {

--- a/pkg/storage/protocol/from_protocol.go
+++ b/pkg/storage/protocol/from_protocol.go
@@ -436,8 +436,7 @@ func (fp *FromProtocol) HandleWriteAt() error {
 			for _, b := range blocks {
 				offset := int64(uint64(b) * blockSize)
 				length := int64(blockSize)
-				// Is provP2P the right thing here? Or should it be prov... or does it matter...
-				storage.SendSiloEvent(fp.provP2P, storage.EventTypeAvailable, storage.EventData([]int64{offset, length}))
+				storage.SendSiloEvent(fp.prov, storage.EventTypeAvailable, storage.EventData([]int64{offset, length}))
 			}
 			continue
 		}
@@ -587,9 +586,9 @@ func (fp *FromProtocol) HandleDirtyList(cb func(blocks []uint)) error {
 			fp.getAltSourcesStartSync()
 		}
 
-		atomic.AddUint64(&fp.metricRecvDirtyList, 1)
-
 		cb(blocks)
+
+		atomic.AddUint64(&fp.metricRecvDirtyList, 1)
 
 		// Send a response / ack, to signify that the DirtyList has been actioned.
 		_, err = fp.protocol.SendPacket(fp.dev, gid, packets.EncodeDirtyListResponse(), UrgencyUrgent)

--- a/pkg/storage/protocol/to_protocol.go
+++ b/pkg/storage/protocol/to_protocol.go
@@ -106,6 +106,10 @@ func (i *ToProtocol) SendSiloEvent(eventType storage.EventType, eventData storag
 	return nil
 }
 
+func (i *ToProtocol) ClearAltSources() {
+	i.alternateSources = nil
+}
+
 func (i *ToProtocol) SendYouAlreadyHave(blockSize uint64, alreadyBlocks []uint32) error {
 	data := packets.EncodeYouAlreadyHave(blockSize, alreadyBlocks)
 	id, err := i.protocol.SendPacket(i.dev, IDPickAny, data, UrgencyUrgent)

--- a/pkg/testutils/minio.go
+++ b/pkg/testutils/minio.go
@@ -10,6 +10,10 @@ import (
 )
 
 func SetupMinio(cleanup func(func())) string {
+	return SetupMinioWithExpiry(cleanup, 180*time.Second)
+}
+
+func SetupMinioWithExpiry(cleanup func(func()), expiry time.Duration) string {
 
 	pool, err := dockertest.NewPool("")
 	if err != nil {
@@ -48,7 +52,7 @@ func SetupMinio(cleanup func(func())) string {
 		}
 	})
 
-	err = resource.Expire(180)
+	err = resource.Expire(uint(expiry.Seconds()))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This prevents an issue if you're sending DirtyList and doing an S3 grab at the same time.

Also adds expiry for minio server for long testing