### PR TITLE
Jamesmoore/arch 325 silo fast init devices

### DIFF
--- a/cmd/create_binlog.go
+++ b/cmd/create_binlog.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/loopholelabs/silo/pkg/storage"
+	"github.com/loopholelabs/silo/pkg/storage/modules"
+	"github.com/loopholelabs/silo/pkg/storage/sources"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdCreateBinlog = &cobra.Command{
+		Use:   "createbinlog",
+		Short: "Create a binlog",
+		Long:  ``,
+		Run:   runCreateBinlog,
+	}
+)
+
+var createBinlogInput string
+var createBinlogOutput string
+var createBinlogBlocksize int
+
+func init() {
+	rootCmd.AddCommand(cmdCreateBinlog)
+	cmdCreateBinlog.Flags().StringVarP(&createBinlogInput, "in", "i", "memory.bin", "Input device file")
+	cmdCreateBinlog.Flags().StringVarP(&createBinlogOutput, "out", "o", "binlog.out", "Binlog output")
+	cmdCreateBinlog.Flags().IntVarP(&createBinlogBlocksize, "bs", "b", 1024*1024, "Block size")
+}
+
+func runCreateBinlog(_ *cobra.Command, _ []string) {
+
+	stat, err := os.Stat(createBinlogInput)
+	if err != nil {
+		panic(err)
+	}
+
+	size := stat.Size()
+
+	source, err := sources.NewFileStorage(createBinlogInput, size)
+	if err != nil {
+		panic(err)
+	}
+
+	dest, err := sources.NewFileStorageCreate(fmt.Sprintf("%s%s", createBinlogInput, ".output"), size)
+	if err != nil {
+		panic(err)
+	}
+	destBinlog, err := modules.NewBinLog(dest, createBinlogOutput)
+	if err != nil {
+		panic(err)
+	}
+
+	err = modules.CreateBinlogFromDevice(source, destBinlog, createBinlogBlocksize)
+	if err != nil {
+		panic(err)
+	}
+
+	// Make *sure* the two devices are equal
+	eq, err := storage.Equals(source, destBinlog, createBinlogBlocksize)
+	if err != nil {
+		panic(err)
+	}
+
+	if !eq {
+		panic("devices are not equal")
+	}
+
+	err = destBinlog.Close()
+	if err != nil {
+		panic(err)
+	}
+
+}

--- a/pkg/storage/config/silo.go
+++ b/pkg/storage/config/silo.go
@@ -26,6 +26,7 @@ type DeviceSchema struct {
 	Location       string        `hcl:"location,optional"`
 	ROSource       *DeviceSchema `hcl:"source,block"`
 	ROSourceShared bool          `hcl:"sourceshared,optional"`
+	LoadBinLog     string        `hcl:"loadbinlog,optional"`
 	Binlog         string        `hcl:"binlog,optional"`
 	PageServerPID  int           `hcl:"pid,optional"`
 	Sync           *SyncS3Schema `hcl:"sync,block"`

--- a/pkg/storage/device/device.go
+++ b/pkg/storage/device/device.go
@@ -136,6 +136,33 @@ func NewDeviceWithLoggingMetrics(ds *config.DeviceSchema, log types.Logger, met 
 			} else {
 				return nil, nil, err
 			}
+
+			// Deal with optional binlogload
+			if ds.LoadBinLog != "" {
+				blr, err := modules.NewBinLogReplay(ds.LoadBinLog, prov)
+				if err != nil {
+					return nil, nil, err
+				}
+				if log != nil {
+					log.Info().
+						Str("source", ds.LoadBinLog).
+						Str("device", ds.Name).
+						Msg("replaying binlog")
+				}
+				provErr, err := blr.ExecuteAll()
+				if provErr != nil {
+					return nil, nil, provErr
+				}
+				if err != nil {
+					return nil, nil, err
+				}
+				if log != nil {
+					log.Info().
+						Str("source", ds.LoadBinLog).
+						Str("device", ds.Name).
+						Msg("binlog replay completed")
+				}
+			}
 		} else {
 			defer file.Close()
 

--- a/pkg/storage/device/device_binlogload_test.go
+++ b/pkg/storage/device/device_binlogload_test.go
@@ -18,7 +18,9 @@ const testFileLoc = "test_device"
 
 func TestDeviceBinlogReplay(t *testing.T) {
 	t.Cleanup(func() {
-		err := os.Remove(testBinlogOut)
+		err := os.Remove(testFileLoc)
+		assert.NoError(t, err)
+		err = os.Remove(testBinlogOut)
 		assert.NoError(t, err)
 	})
 

--- a/pkg/storage/device/device_binlogload_test.go
+++ b/pkg/storage/device/device_binlogload_test.go
@@ -1,0 +1,72 @@
+package device
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/loopholelabs/silo/pkg/storage"
+	"github.com/loopholelabs/silo/pkg/storage/config"
+	"github.com/loopholelabs/silo/pkg/storage/modules"
+	"github.com/loopholelabs/silo/pkg/storage/sources"
+	"github.com/stretchr/testify/assert"
+)
+
+const testBinlogOut = "test_binlog.out"
+const testFileLoc = "test_device"
+
+func TestDeviceBinlogReplay(t *testing.T) {
+	t.Cleanup(func() {
+		err := os.Remove(testBinlogOut)
+		assert.NoError(t, err)
+	})
+
+	source := sources.NewMemoryStorage(1024 * 1024)
+
+	dest := sources.NewMemoryStorage(1024 * 1024)
+	destBinlog, err := modules.NewBinLog(dest, testBinlogOut)
+	assert.NoError(t, err)
+
+	// Do a few little writes
+
+	data := make([]byte, 500)
+	rand.Read(data)
+	_, err = source.WriteAt(data, 100)
+	assert.NoError(t, err)
+	_, err = source.WriteAt(data, 900)
+	assert.NoError(t, err)
+	_, err = source.WriteAt(data, 20000)
+	assert.NoError(t, err)
+
+	// Create the binlog
+
+	err = modules.CreateBinlogFromDevice(source, destBinlog, 1024)
+	assert.NoError(t, err)
+
+	// Make sure the devices are equal
+	eq, err := storage.Equals(source, destBinlog, 1024)
+	assert.NoError(t, err)
+	assert.True(t, eq)
+
+	destBinlog.Close()
+
+	// Now try a replay with device
+
+	d, _, err := NewDevice(&config.DeviceSchema{
+		Name:       "test",
+		Size:       fmt.Sprintf("%d", source.Size()),
+		System:     "file",
+		BlockSize:  "1024",
+		Expose:     false,
+		Location:   testFileLoc,
+		LoadBinLog: testBinlogOut,
+	})
+	assert.NoError(t, err)
+
+	// Now check these two devices are equal
+	eq, err = storage.Equals(source, d, 1024)
+	assert.NoError(t, err)
+	assert.True(t, eq)
+
+}

--- a/pkg/storage/modules/binlog_replay.go
+++ b/pkg/storage/modules/binlog_replay.go
@@ -113,3 +113,19 @@ func (i *BinLogReplay) Next(speed float64, execute bool) (error, error) {
 	}
 	return nil, nil
 }
+
+func (i *BinLogReplay) ExecuteAll() (error, error) {
+	for {
+		provErr, err := i.Next(0, true)
+		if provErr != nil {
+			return provErr, err
+		}
+		if err != nil {
+			if err == io.EOF {
+				break // All done
+			}
+			return nil, err
+		}
+	}
+	return nil, nil
+}

--- a/pkg/storage/modules/binlog_test.go
+++ b/pkg/storage/modules/binlog_test.go
@@ -1,0 +1,72 @@
+package modules
+
+import (
+	"crypto/rand"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/loopholelabs/silo/pkg/storage"
+	"github.com/loopholelabs/silo/pkg/storage/sources"
+	"github.com/stretchr/testify/assert"
+)
+
+const testBinlogOut = "test_binlog.out"
+
+func TestBinlog(t *testing.T) {
+	t.Cleanup(func() {
+		err := os.Remove(testBinlogOut)
+		assert.NoError(t, err)
+	})
+
+	source := sources.NewMemoryStorage(1024 * 1024)
+
+	dest := sources.NewMemoryStorage(1024 * 1024)
+	destBinlog, err := NewBinLog(dest, testBinlogOut)
+	assert.NoError(t, err)
+
+	// Do a few little writes
+
+	data := make([]byte, 500)
+	rand.Read(data)
+	_, err = source.WriteAt(data, 100)
+	assert.NoError(t, err)
+	_, err = source.WriteAt(data, 900)
+	assert.NoError(t, err)
+	_, err = source.WriteAt(data, 20000)
+	assert.NoError(t, err)
+
+	// Create the binlog
+
+	err = CreateBinlogFromDevice(source, destBinlog, 1024)
+	assert.NoError(t, err)
+
+	// Make sure the devices are equal
+	eq, err := storage.Equals(source, destBinlog, 1024)
+	assert.NoError(t, err)
+	assert.True(t, eq)
+
+	destBinlog.Close()
+
+	// Now try a replay
+	nextDevice := sources.NewMemoryStorage(1024 * 1024)
+	binReplay, err := NewBinLogReplay(testBinlogOut, nextDevice)
+	assert.NoError(t, err)
+
+	for {
+		provErr, err := binReplay.Next(0, true)
+		assert.NoError(t, provErr)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			assert.NoError(t, err) // Shouldn't be any other error
+		}
+	}
+
+	// Now check these two devices are equal
+	eq, err = storage.Equals(source, nextDevice, 1024)
+	assert.NoError(t, err)
+	assert.True(t, eq)
+
+}

--- a/pkg/storage/modules/binlog_test.go
+++ b/pkg/storage/modules/binlog_test.go
@@ -2,7 +2,6 @@ package modules
 
 import (
 	"crypto/rand"
-	"io"
 	"os"
 	"testing"
 
@@ -53,16 +52,9 @@ func TestBinlog(t *testing.T) {
 	binReplay, err := NewBinLogReplay(testBinlogOut, nextDevice)
 	assert.NoError(t, err)
 
-	for {
-		provErr, err := binReplay.Next(0, true)
-		assert.NoError(t, provErr)
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			assert.NoError(t, err) // Shouldn't be any other error
-		}
-	}
+	provErr, err := binReplay.ExecuteAll()
+	assert.NoError(t, provErr)
+	assert.NoError(t, err)
 
 	// Now check these two devices are equal
 	eq, err = storage.Equals(source, nextDevice, 1024)

--- a/pkg/storage/modules/binlog_util.go
+++ b/pkg/storage/modules/binlog_util.go
@@ -1,0 +1,31 @@
+package modules
+
+import "github.com/loopholelabs/silo/pkg/storage"
+
+func CreateBinlogFromDevice(source storage.Provider, dest storage.Provider, blockSize int) error {
+	buffer := make([]byte, blockSize)
+
+	for offset := int64(0); offset < int64(source.Size()); offset += int64(blockSize) {
+		n, err := source.ReadAt(buffer, offset)
+		if err != nil {
+			return err
+		}
+
+		// Check if it's all zeros
+		empty := true
+		for f := 0; f < n; f++ {
+			if buffer[f] != 0 {
+				empty = false
+				break
+			}
+		}
+
+		if !empty {
+			_, err = dest.WriteAt(buffer[:n], offset)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR allows us to speed up device init in some situations, by doing a binlog replay on the device at startup.
It also means that shipping around blueprints and snapshots can be significantly smaller. (For example memory.bin may be a few hundred MB rather than 8GB).

* There is a tool called /cmd/createbinlog. Given a file, it will create a binlog which is essentially a collection of WriteAt calls with data.
* When initializing a device, we can use new config `loadbinlog` to point to a binlog which will replay instantly.

This means that rather than having an 8GB memory file for example, which may need to be streamed in / decompressed from filesystem etc etc, we instead truncate a new file to 8GB and then do a few little writes to create the data.

There is a new test showing the functionality in device.