### PR TITLE
Jamesmoore/arch 329 silometrics shouldnt be global

### DIFF
--- a/pkg/storage/devicegroup/device_group_to.go
+++ b/pkg/storage/devicegroup/device_group_to.go
@@ -10,7 +10,6 @@ import (
 	"github.com/loopholelabs/silo/pkg/storage/config"
 	"github.com/loopholelabs/silo/pkg/storage/device"
 	"github.com/loopholelabs/silo/pkg/storage/dirtytracker"
-	"github.com/loopholelabs/silo/pkg/storage/expose"
 	"github.com/loopholelabs/silo/pkg/storage/metrics"
 	"github.com/loopholelabs/silo/pkg/storage/migrator"
 	"github.com/loopholelabs/silo/pkg/storage/modules"
@@ -69,9 +68,6 @@ func NewFromSchema(instanceID string, ds []*config.DeviceSchema, createWC bool, 
 		// Add to metrics if given.
 		if met != nil {
 			met.AddMetrics(dg.instanceID, s.Name, mlocal)
-			if exp != nil {
-				met.AddNBD(dg.instanceID, s.Name, exp.(*expose.ExposedStorageNBDNL))
-			}
 			met.AddDirtyTracker(dg.instanceID, s.Name, dirtyRemote)
 			met.AddVolatilityMonitor(dg.instanceID, s.Name, vmonitor)
 		}

--- a/pkg/storage/metrics/metrics.go
+++ b/pkg/storage/metrics/metrics.go
@@ -13,6 +13,7 @@ import (
 
 type SiloMetrics interface {
 	Shutdown()
+	RemoveAllID(id string)
 
 	AddSyncer(id string, name string, sync *migrator.Syncer)
 	RemoveSyncer(id string, name string)

--- a/pkg/storage/metrics/prometheus/prometheus.go
+++ b/pkg/storage/metrics/prometheus/prometheus.go
@@ -512,6 +512,7 @@ func (m *Metrics) add(subsystem string, id string, name string, interval time.Du
 	cancelfns, ok := m.cancelfns[id]
 	if !ok {
 		cancelfns = make(map[string]context.CancelFunc)
+		m.cancelfns[id] = cancelfns
 	}
 	cancelfns[fmt.Sprintf("%s_%s", subsystem, name)] = cancelfn
 	m.lock.Unlock()

--- a/pkg/storage/metrics/prometheus/prometheus.go
+++ b/pkg/storage/metrics/prometheus/prometheus.go
@@ -68,7 +68,7 @@ func DefaultConfig() *MetricsConfig {
 		TickDirtyTracker:      100 * time.Millisecond,
 		TickVolatilityMonitor: 100 * time.Millisecond,
 		TickMetrics:           100 * time.Millisecond,
-		TickNBD:               500 * time.Millisecond,
+		TickNBD:               100 * time.Millisecond,
 		TickWaitingCache:      100 * time.Millisecond,
 	}
 }

--- a/pkg/storage/metrics/prometheus/prometheus.go
+++ b/pkg/storage/metrics/prometheus/prometheus.go
@@ -198,7 +198,7 @@ type Metrics struct {
 	waitingCacheAvailableLocal           *prometheus.GaugeVec
 	waitingCacheAvailableRemote          *prometheus.GaugeVec
 
-	cancelfns map[string]context.CancelFunc
+	cancelfns map[string]map[string]context.CancelFunc
 }
 
 func New(reg prometheus.Registerer, config *MetricsConfig) *Metrics {
@@ -426,7 +426,7 @@ func New(reg prometheus.Registerer, config *MetricsConfig) *Metrics {
 		waitingCacheAvailableRemote: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: config.Namespace, Subsystem: config.SubWaitingCache, Name: "available_remote", Help: "AvailableRemote"}, labels),
 
-		cancelfns: make(map[string]context.CancelFunc),
+		cancelfns: make(map[string]map[string]context.CancelFunc),
 	}
 
 	// Register all the metrics
@@ -492,10 +492,16 @@ func New(reg prometheus.Registerer, config *MetricsConfig) *Metrics {
 
 func (m *Metrics) remove(subsystem string, id string, name string) {
 	m.lock.Lock()
-	cancelfn, ok := m.cancelfns[fmt.Sprintf("%s_%s_%s", subsystem, id, name)]
+	cancelfns, ok := m.cancelfns[id]
 	if ok {
-		cancelfn()
-		delete(m.cancelfns, fmt.Sprintf("%s_%s_%s", subsystem, id, name))
+		cancelfn, ok := cancelfns[fmt.Sprintf("%s_%s", subsystem, name)]
+		if ok {
+			cancelfn()
+			delete(cancelfns, fmt.Sprintf("%s_%s", subsystem, name))
+			if len(cancelfns) == 0 {
+				delete(m.cancelfns, id)
+			}
+		}
 	}
 	m.lock.Unlock()
 }
@@ -503,7 +509,11 @@ func (m *Metrics) remove(subsystem string, id string, name string) {
 func (m *Metrics) add(subsystem string, id string, name string, interval time.Duration, tickfn func()) {
 	ctx, cancelfn := context.WithCancel(context.TODO())
 	m.lock.Lock()
-	m.cancelfns[fmt.Sprintf("%s_%s_%s", subsystem, id, name)] = cancelfn
+	cancelfns, ok := m.cancelfns[id]
+	if !ok {
+		cancelfns = make(map[string]context.CancelFunc)
+	}
+	cancelfns[fmt.Sprintf("%s_%s", subsystem, name)] = cancelfn
 	m.lock.Unlock()
 
 	ticker := time.NewTicker(interval)
@@ -522,10 +532,25 @@ func (m *Metrics) add(subsystem string, id string, name string, interval time.Du
 // Shutdown everything
 func (m *Metrics) Shutdown() {
 	m.lock.Lock()
-	for _, cancelfn := range m.cancelfns {
-		cancelfn()
+	for _, cancelfns := range m.cancelfns {
+		for _, cancelfn := range cancelfns {
+			cancelfn()
+		}
 	}
-	m.cancelfns = make(map[string]context.CancelFunc)
+	m.cancelfns = make(map[string]map[string]context.CancelFunc)
+	m.lock.Unlock()
+}
+
+// Remove everything associated with the given id
+func (m *Metrics) RemoveAllID(id string) {
+	m.lock.Lock()
+	cancelfns, ok := m.cancelfns[id]
+	if ok {
+		for _, cancelfn := range cancelfns {
+			cancelfn()
+		}
+		delete(m.cancelfns, id)
+	}
 	m.lock.Unlock()
 }
 


### PR DESCRIPTION
This adds a RemoveAllID func to SiloMetrics, and fixes a duplicate metrics issue which may have leaked goroutines over sustained runs with lots of migrations.