### PR TITLE
Fixed issue with nbd failures when less than 1 block

### DIFF
--- a/pkg/storage/expose/nbd.go
+++ b/pkg/storage/expose/nbd.go
@@ -19,6 +19,7 @@ import (
 
 const NBDDefaultBlockSize = 4096
 
+const NBDMinSectors = 8
 const NBDAlignSectorSize = 512
 
 var DefaultConfig = &Config{
@@ -116,6 +117,10 @@ func NewExposedStorageNBDNL(prov storage.Provider, conf *Config) *ExposedStorage
 
 	// The size must be a multiple of sector size
 	size = NBDAlignSectorSize * ((size + NBDAlignSectorSize - 1) / NBDAlignSectorSize)
+
+	if size < NBDAlignSectorSize*NBDMinSectors {
+		size = NBDAlignSectorSize * NBDMinSectors
+	}
 
 	ctx, cancelfn := context.WithCancel(context.TODO())
 

--- a/pkg/storage/expose/nbd_test.go
+++ b/pkg/storage/expose/nbd_test.go
@@ -122,12 +122,12 @@ func TestNBDNLDeviceSmall(t *testing.T) {
 	size := 900
 	prov := sources.NewMemoryStorage(size)
 
-	b := make([]byte, 900)
+	b := make([]byte, size)
 	_, err = rand.Read(b)
 	assert.NoError(t, err)
 	n, err := prov.WriteAt(b, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, 900, n)
+	assert.Equal(t, size, n)
 
 	ndev = NewExposedStorageNBDNL(prov, DefaultConfig.WithNumConnections(1))
 
@@ -138,10 +138,10 @@ func TestNBDNLDeviceSmall(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Try doing a read...
-	buffer := make([]byte, 900)
+	buffer := make([]byte, size)
 	num, err := devfile.ReadAt(buffer, 0)
 	assert.NoError(t, err)
-	assert.Equal(t, 900, num)
+	assert.Equal(t, size, num)
 	devfile.Close()
 
 	// Make sure the data is equal
@@ -219,7 +219,7 @@ func TestNBDNLDeviceUnalignedPartialWrite(t *testing.T) {
 	devfile, err := os.OpenFile(fmt.Sprintf("/dev/nbd%d", ndev.deviceIndex), os.O_RDWR, 0666)
 	assert.NoError(t, err)
 
-	// Try doing a read...
+	// Try doing a WriteAt...
 	buffer := make([]byte, 800)
 	_, err = rand.Read(buffer)
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixed tests that no longer work with latest nbd drivers (minimum size etc)