### PR TITLE
Jamesmoore/arch 354 add option to disable volatilitymonitor in silo

### DIFF
--- a/pkg/storage/config/silo.go
+++ b/pkg/storage/config/silo.go
@@ -18,19 +18,24 @@ type SiloSchema struct {
 }
 
 type DeviceSchema struct {
-	Name           string        `hcl:"name,label"`
-	Size           string        `hcl:"size,attr"`
-	System         string        `hcl:"system,attr"`
-	BlockSize      string        `hcl:"blocksize,optional"`
-	Expose         bool          `hcl:"expose,optional"`
-	Location       string        `hcl:"location,optional"`
-	ROSource       *DeviceSchema `hcl:"source,block"`
-	ROSourceHashes string        `hcl:"sourcehashes,optional"`
-	ROSourceShared bool          `hcl:"sourceshared,optional"`
-	LoadBinLog     string        `hcl:"loadbinlog,optional"`
-	Binlog         string        `hcl:"binlog,optional"`
-	PageServerPID  int           `hcl:"pid,optional"`
-	Sync           *SyncS3Schema `hcl:"sync,block"`
+	Name           string                 `hcl:"name,label"`
+	Size           string                 `hcl:"size,attr"`
+	System         string                 `hcl:"system,attr"`
+	BlockSize      string                 `hcl:"blocksize,optional"`
+	Expose         bool                   `hcl:"expose,optional"`
+	Location       string                 `hcl:"location,optional"`
+	ROSource       *DeviceSchema          `hcl:"source,block"`
+	ROSourceHashes string                 `hcl:"sourcehashes,optional"`
+	ROSourceShared bool                   `hcl:"sourceshared,optional"`
+	LoadBinLog     string                 `hcl:"loadbinlog,optional"`
+	Binlog         string                 `hcl:"binlog,optional"`
+	PageServerPID  int                    `hcl:"pid,optional"`
+	Sync           *SyncS3Schema          `hcl:"sync,block"`
+	Migration      *MigrationConfigSchema `hcl:"migration,block"`
+}
+
+type MigrationConfigSchema struct {
+	AnyOrder bool `hcl:"anyorder,attr"`
 }
 
 type SyncConfigSchema struct {

--- a/pkg/storage/devicegroup/device_group_test.go
+++ b/pkg/storage/devicegroup/device_group_test.go
@@ -30,6 +30,9 @@ var testDeviceSchema = []*config.DeviceSchema{
 		BlockSize: "1m",
 		//	Expose:    true,
 		Location: "test_data/test1",
+		Migration: &config.MigrationConfigSchema{
+			AnyOrder: true,
+		},
 	},
 
 	{
@@ -325,6 +328,13 @@ func TestDeviceGroupMigrate(t *testing.T) {
 		eq, err := storage.Equals(prov, destProvider, 1024*1024)
 		assert.NoError(t, err)
 		assert.True(t, eq)
+
+		di := dg.GetDeviceInformationByName(s.Name)
+		if s.Name == "test1" {
+			assert.Nil(t, di.Volatility)
+		} else {
+			assert.NotNil(t, di.Volatility)
+		}
 	}
 
 	// Cancel context

--- a/pkg/storage/devicegroup/device_group_to.go
+++ b/pkg/storage/devicegroup/device_group_to.go
@@ -59,6 +59,7 @@ func NewFromSchema(instanceID string, ds []*config.DeviceSchema, createWC bool, 
 		totalBlocks := (int(local.Size()) + blockSize - 1) / blockSize
 
 		var vmonitor *volatilitymonitor.VolatilityMonitor
+		var order storage.BlockOrder
 
 		if s.Migration == nil || !s.Migration.AnyOrder {
 			vmonitor = volatilitymonitor.NewVolatilityMonitor(dirtyLocal, blockSize, volatilityExpiry)
@@ -68,9 +69,12 @@ func NewFromSchema(instanceID string, ds []*config.DeviceSchema, createWC bool, 
 			if met != nil {
 				met.AddVolatilityMonitor(dg.instanceID, s.Name, vmonitor)
 			}
+			order = vmonitor
+		} else {
+			order = blocks.NewAnyBlockOrder(totalBlocks, nil)
 		}
 
-		orderer := blocks.NewPriorityBlockOrder(totalBlocks, vmonitor)
+		orderer := blocks.NewPriorityBlockOrder(totalBlocks, order)
 		orderer.AddAll()
 
 		// Add to metrics if given.

--- a/pkg/storage/devicegroup/device_group_to.go
+++ b/pkg/storage/devicegroup/device_group_to.go
@@ -61,7 +61,9 @@ func NewFromSchema(instanceID string, ds []*config.DeviceSchema, createWC bool, 
 		var vmonitor *volatilitymonitor.VolatilityMonitor
 		var order storage.BlockOrder
 
-		if s.Migration == nil || !s.Migration.AnyOrder {
+		if s.Migration != nil && s.Migration.AnyOrder {
+			order = blocks.NewAnyBlockOrder(totalBlocks, nil)
+		} else {
 			vmonitor = volatilitymonitor.NewVolatilityMonitor(dirtyLocal, blockSize, volatilityExpiry)
 			if exp != nil {
 				exp.SetProvider(vmonitor)
@@ -70,8 +72,6 @@ func NewFromSchema(instanceID string, ds []*config.DeviceSchema, createWC bool, 
 				met.AddVolatilityMonitor(dg.instanceID, s.Name, vmonitor)
 			}
 			order = vmonitor
-		} else {
-			order = blocks.NewAnyBlockOrder(totalBlocks, nil)
 		}
 
 		orderer := blocks.NewPriorityBlockOrder(totalBlocks, order)


### PR DESCRIPTION
This PR adds an option to disable VolatilityMonitor per device, which can reduce CPU usage.

VolatilityMonitors purpose is to monitor the writes on a per block basis, and then when a migration happens, it is able to send blocks in the best order - from least volatile to most volatile. This reduces the amount of dirty blocks, and reduces the data transfer when we are doing dirty loops.

However, if we just want to 'evacuate' quickly, rather than minimizing downtime, there is no benefit to using volatilityMonitor, and it just increases CPU load.

The PR adds a new device config which can be used in the future to hold any other migration type options. This starts with the bool "AnyOrder". If set to true, then VolatilityMonitor will not be used for the device.