### PR TITLE
Jamesmoore/arch 350 add statsd option to silo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/rs/zerolog v1.33.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	github.com/smira/go-statsd v1.3.4 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/rs/zerolog v1.33.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWR
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/smira/go-statsd v1.3.4 h1:kBYWcLSGT+qC6JVbvfz48kX7mQys32fjDOPrfmsSx2c=
+github.com/smira/go-statsd v1.3.4/go.mod h1:RjdsESPgDODtg1VpVVf9MJrEW2Hw0wtRNbmB1CAhu6A=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=

--- a/pkg/storage/metrics/statsd/statsd.go
+++ b/pkg/storage/metrics/statsd/statsd.go
@@ -88,6 +88,7 @@ type Metrics struct {
 func New(addr string, config *MetricsConfig) *Metrics {
 	client := statsd.NewClient(addr,
 		statsd.MaxPacketSize(1400),
+		statsd.TagStyle(statsd.TagFormatDatadog),
 		statsd.MetricPrefix("silo."))
 
 	return &Metrics{
@@ -227,20 +228,42 @@ func (m *Metrics) RemoveMetrics(id string, name string) {
 }
 
 func (m *Metrics) AddNBD(id string, name string, mm *expose.ExposedStorageNBDNL) {
+	lastmet := mm.GetMetrics()
+
 	m.add(m.config.SubNBD, id, name, m.config.TickNBD, func() {
 		met := mm.GetMetrics()
-		m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "packets_in"), int64(met.PacketsIn), statsd.StringTag("id", id), statsd.StringTag("name", name))
-		m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "packets_out"), int64(met.PacketsOut), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		if lastmet.PacketsIn != met.PacketsIn {
+			m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "packets_in"), int64(met.PacketsIn), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		}
+		if lastmet.PacketsOut != met.PacketsOut {
+			m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "packets_out"), int64(met.PacketsOut), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		}
+		if lastmet.ReadAt != met.ReadAt {
+			m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "read_at"), int64(met.ReadAt), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		}
+		if lastmet.ReadAtBytes != met.ReadAtBytes {
+			m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "read_at_bytes"), int64(met.ReadAtBytes), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		}
+		if lastmet.ReadAtTime != met.ReadAtTime {
+			m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "read_at_time"), int64(met.ReadAtTime), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		}
+		if lastmet.ActiveReads != met.ActiveReads {
+			m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "active_reads"), int64(met.ActiveReads), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		}
 
-		m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "read_at"), int64(met.ReadAt), statsd.StringTag("id", id), statsd.StringTag("name", name))
-		m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "read_at_bytes"), int64(met.ReadAtBytes), statsd.StringTag("id", id), statsd.StringTag("name", name))
-		m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "read_at_time"), int64(met.ReadAtTime), statsd.StringTag("id", id), statsd.StringTag("name", name))
-		m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "active_reads"), int64(met.ActiveReads), statsd.StringTag("id", id), statsd.StringTag("name", name))
-
-		m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "write_at"), int64(met.WriteAt), statsd.StringTag("id", id), statsd.StringTag("name", name))
-		m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "write_at_bytes"), int64(met.WriteAtBytes), statsd.StringTag("id", id), statsd.StringTag("name", name))
-		m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "write_at_time"), int64(met.WriteAtTime), statsd.StringTag("id", id), statsd.StringTag("name", name))
-		m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "active_writes"), int64(met.ActiveWrites), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		if lastmet.WriteAt != met.WriteAt {
+			m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "write_at"), int64(met.WriteAt), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		}
+		if lastmet.WriteAtBytes != met.WriteAtBytes {
+			m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "write_at_bytes"), int64(met.WriteAtBytes), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		}
+		if lastmet.WriteAtTime != met.WriteAtTime {
+			m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "write_at_time"), int64(met.WriteAtTime), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		}
+		if lastmet.ActiveWrites != met.ActiveWrites {
+			m.client.Gauge(fmt.Sprintf("%s_%s", m.config.SubNBD, "active_writes"), int64(met.ActiveWrites), statsd.StringTag("id", id), statsd.StringTag("name", name))
+		}
+		lastmet = met
 	})
 }
 func (m *Metrics) RemoveNBD(id string, name string) {

--- a/pkg/storage/metrics/statsd/statsd.go
+++ b/pkg/storage/metrics/statsd/statsd.go
@@ -263,7 +263,84 @@ func (m *Metrics) RemoveToProtocol(id string, name string) {
 	m.remove(m.config.SubToProtocol, id, name)
 }
 
-func (m *Metrics) AddFromProtocol(id string, name string, proto *protocol.FromProtocol) {}
+func (m *Metrics) AddFromProtocol(id string, name string, proto *protocol.FromProtocol) {
+	lastmet := &protocol.FromProtocolMetrics{
+		AvailableP2P:        make([]uint, 0),
+		DuplicateP2P:        make([]uint, 0),
+		AvailableAltSources: make([]uint, 0),
+	}
+	m.add(m.config.SubFromProtocol, id, name, m.config.TickFromProtocol, func() {
+		met := proto.GetMetrics()
+
+		if met.DeviceName != "" {
+			name = met.DeviceName
+		}
+
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_events", lastmet.RecvEvents, met.RecvEvents)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_hashes", lastmet.RecvHashes, met.RecvHashes)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_dev_info", lastmet.RecvDevInfo, met.RecvDevInfo)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_alt_sources", lastmet.RecvAltSources, met.RecvAltSources)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_read_at", lastmet.RecvReadAt, met.RecvReadAt)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_write_at_hash", lastmet.RecvWriteAtHash, met.RecvWriteAtHash)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_write_at_comp", lastmet.RecvWriteAtComp, met.RecvWriteAtComp)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_write_at", lastmet.RecvWriteAt, met.RecvWriteAt)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_write_at_with_map", lastmet.RecvWriteAtWithMap, met.RecvWriteAtWithMap)
+
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_remove_from_map", lastmet.RecvRemoveFromMap, met.RecvRemoveFromMap)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_remove_dev", lastmet.RecvRemoveDev, met.RecvRemoveDev)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "recv_dirty_list", lastmet.RecvDirtyList, met.RecvDirtyList)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "sent_need_at", lastmet.SentNeedAt, met.SentNeedAt)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "sent_dont_need_at", lastmet.SentDontNeedAt, met.SentDontNeedAt)
+
+		m.updateMetric(id, name, m.config.SubFromProtocol, "writes_allowed_p2p", lastmet.WritesAllowedP2P, met.WritesAllowedP2P)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "writes_blocked_p2p", lastmet.WritesBlockedP2P, met.WritesBlockedP2P)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "writes_allowed_alt_sources", lastmet.WritesAllowedAltSources, met.WritesAllowedAltSources)
+		m.updateMetric(id, name, m.config.SubFromProtocol, "writes_blocked_alt_sources", lastmet.WritesBlockedAltSources, met.WritesBlockedAltSources)
+
+		/*
+			   Namespace: config.Namespace, Subsystem: config.SubFromProtocol, Name: "heatmap", Help: "Heatmap"}, append(labels, "le")),
+
+				totalHeatmapP2P := make([]uint64, m.config.HeatmapResolution)
+				for _, block := range met.AvailableP2P {
+					part := uint64(block) * m.config.HeatmapResolution / met.NumBlocks
+					totalHeatmapP2P[part]++
+				}
+
+				totalHeatmapAltSources := make([]uint64, m.config.HeatmapResolution)
+				for _, block := range met.AvailableAltSources {
+					part := uint64(block) * m.config.HeatmapResolution / met.NumBlocks
+					totalHeatmapAltSources[part]++
+				}
+
+				totalHeatmapP2PDupe := make([]uint64, m.config.HeatmapResolution)
+				for _, block := range met.DuplicateP2P {
+					part := uint64(block) * m.config.HeatmapResolution / met.NumBlocks
+					totalHeatmapP2PDupe[part]++
+				}
+
+				blocksPerPart := 2 * (met.NumBlocks / m.config.HeatmapResolution)
+
+				//
+				for part, blocks := range totalHeatmapP2P {
+					m.fromProtocolHeatmap.WithLabelValues(id, name, fmt.Sprintf("%d", part)).Set(float64(blocks))
+				}
+
+				for part, blocks := range totalHeatmapAltSources {
+					if blocks > 0 {
+						m.fromProtocolHeatmap.WithLabelValues(id, name, fmt.Sprintf("%d", part)).Set(float64(blocksPerPart*2 + blocks))
+					}
+				}
+
+				for part, blocks := range totalHeatmapP2PDupe {
+					if blocks > 0 {
+						m.fromProtocolHeatmap.WithLabelValues(id, name, fmt.Sprintf("%d", part)).Set(float64(blocksPerPart + blocks))
+					}
+				}
+		*/
+		lastmet = met
+	})
+
+}
 func (m *Metrics) RemoveFromProtocol(id string, name string) {
 	m.remove(m.config.SubFromProtocol, id, name)
 }

--- a/pkg/storage/metrics/statsd/statsd.go
+++ b/pkg/storage/metrics/statsd/statsd.go
@@ -1,0 +1,3 @@
+package statsd
+
+// TODO: Needs to implement SiloMetrics ifc.

--- a/pkg/storage/metrics/statsd/statsd.go
+++ b/pkg/storage/metrics/statsd/statsd.go
@@ -233,7 +233,32 @@ func (m *Metrics) RemoveProtocol(id string, name string) {
 	m.remove(m.config.SubProtocol, id, name)
 }
 
-func (m *Metrics) AddToProtocol(id string, name string, proto *protocol.ToProtocol) {}
+func (m *Metrics) AddToProtocol(id string, name string, proto *protocol.ToProtocol) {
+	lastmet := &protocol.ToProtocolMetrics{}
+	m.add(m.config.SubToProtocol, id, name, m.config.TickToProtocol, func() {
+		met := proto.GetMetrics()
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_events", lastmet.SentEvents, met.SentEvents)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_alt_sources", lastmet.SentAltSources, met.SentAltSources)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_hashes", lastmet.SentHashes, met.SentHashes)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_dev_info", lastmet.SentDevInfo, met.SentDevInfo)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_dirty_list", lastmet.SentDirtyList, met.SentDirtyList)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_read_at", lastmet.SentReadAt, met.SentReadAt)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_write_at_hash", lastmet.SentWriteAtHash, met.SentWriteAtHash)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_write_at_hash_bytes", lastmet.SentWriteAtHashBytes, met.SentWriteAtHashBytes)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_write_at_comp", lastmet.SentWriteAtComp, met.SentWriteAtComp)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_write_at_comp_bytes", lastmet.SentWriteAtCompBytes, met.SentWriteAtCompBytes)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_write_at_comp_data_bytes", lastmet.SentWriteAtCompDataBytes, met.SentWriteAtCompDataBytes)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_write_at", lastmet.SentWriteAt, met.SentWriteAt)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_write_at_bytes", lastmet.SentWriteAtBytes, met.SentWriteAtBytes)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_write_at_with_map", lastmet.SentWriteAtWithMap, met.SentWriteAtWithMap)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_remove_from_map", lastmet.SentRemoveFromMap, met.SentRemoveFromMap)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_you_already_have", lastmet.SentYouAlreadyHave, met.SentYouAlreadyHave)
+		m.updateMetric(id, name, m.config.SubToProtocol, "sent_you_already_have_bytes", lastmet.SentYouAlreadyHaveBytes, met.SentYouAlreadyHaveBytes)
+		m.updateMetric(id, name, m.config.SubToProtocol, "recv_need_at", lastmet.RecvNeedAt, met.RecvNeedAt)
+		m.updateMetric(id, name, m.config.SubToProtocol, "recv_dont_need_at", lastmet.RecvDontNeedAt, met.RecvDontNeedAt)
+		lastmet = met
+	})
+}
 func (m *Metrics) RemoveToProtocol(id string, name string) {
 	m.remove(m.config.SubToProtocol, id, name)
 }

--- a/pkg/storage/metrics/statsd/statsd.go
+++ b/pkg/storage/metrics/statsd/statsd.go
@@ -1,3 +1,69 @@
 package statsd
 
-// TODO: Needs to implement SiloMetrics ifc.
+import (
+	"github.com/loopholelabs/silo/pkg/storage/dirtytracker"
+	"github.com/loopholelabs/silo/pkg/storage/expose"
+	"github.com/loopholelabs/silo/pkg/storage/migrator"
+	"github.com/loopholelabs/silo/pkg/storage/modules"
+	"github.com/loopholelabs/silo/pkg/storage/protocol"
+	"github.com/loopholelabs/silo/pkg/storage/sources"
+	"github.com/loopholelabs/silo/pkg/storage/volatilitymonitor"
+	"github.com/loopholelabs/silo/pkg/storage/waitingcache"
+
+	"github.com/smira/go-statsd"
+)
+
+type Metrics struct {
+	client *statsd.Client
+}
+
+func NewMetrics() *Metrics {
+	client := statsd.NewClient("localhost:8125",
+		statsd.MaxPacketSize(1400),
+		statsd.MetricPrefix("silo."))
+
+	return &Metrics{
+		client: client,
+	}
+}
+
+func (m *Metrics) Shutdown() {}
+
+func (m *Metrics) RemoveAllID(id string) {}
+
+func (m *Metrics) AddSyncer(id string, name string, sync *migrator.Syncer) {}
+func (m *Metrics) RemoveSyncer(id string, name string)                     {}
+
+func (m *Metrics) AddMigrator(id string, name string, mig *migrator.Migrator) {}
+func (m *Metrics) RemoveMigrator(id string, name string)                      {}
+
+func (m *Metrics) AddProtocol(id string, name string, proto *protocol.RW) {}
+func (m *Metrics) RemoveProtocol(id string, name string)                  {}
+
+func (m *Metrics) AddToProtocol(id string, name string, proto *protocol.ToProtocol) {}
+func (m *Metrics) RemoveToProtocol(id string, name string)                          {}
+
+func (m *Metrics) AddFromProtocol(id string, name string, proto *protocol.FromProtocol) {}
+func (m *Metrics) RemoveFromProtocol(id string, name string)                            {}
+
+func (m *Metrics) AddS3Storage(id string, name string, s3 *sources.S3Storage) {}
+func (m *Metrics) RemoveS3Storage(id string, name string)                     {}
+
+func (m *Metrics) AddDirtyTracker(id string, name string, dt *dirtytracker.Remote) {}
+func (m *Metrics) RemoveDirtyTracker(id string, name string)                       {}
+
+func (m *Metrics) AddVolatilityMonitor(id string, name string, vm *volatilitymonitor.VolatilityMonitor) {
+}
+func (m *Metrics) RemoveVolatilityMonitor(id string, name string) {}
+
+func (m *Metrics) AddMetrics(id string, name string, mm *modules.Metrics) {}
+func (m *Metrics) RemoveMetrics(id string, name string)                   {}
+
+func (m *Metrics) AddNBD(id string, name string, mm *expose.ExposedStorageNBDNL) {}
+func (m *Metrics) RemoveNBD(id string, name string)                              {}
+
+func (m *Metrics) AddWaitingCache(id string, name string, wc *waitingcache.Remote) {}
+func (m *Metrics) RemoveWaitingCache(id string, name string)                       {}
+
+func (m *Metrics) AddCopyOnWrite(id string, name string, cow *modules.CopyOnWrite) {}
+func (m *Metrics) RemoveCopyOnWrite(id string, name string)                        {}

--- a/pkg/storage/metrics/statsd/statsd.go
+++ b/pkg/storage/metrics/statsd/statsd.go
@@ -1,6 +1,11 @@
 package statsd
 
 import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
 	"github.com/loopholelabs/silo/pkg/storage/dirtytracker"
 	"github.com/loopholelabs/silo/pkg/storage/expose"
 	"github.com/loopholelabs/silo/pkg/storage/migrator"
@@ -13,57 +18,213 @@ import (
 	"github.com/smira/go-statsd"
 )
 
-type Metrics struct {
-	client *statsd.Client
+type MetricsConfig struct {
+	HeatmapResolution     uint64
+	Namespace             string
+	SubSyncer             string
+	SubMigrator           string
+	SubProtocol           string
+	SubToProtocol         string
+	SubFromProtocol       string
+	SubS3                 string
+	SubDirtyTracker       string
+	SubVolatilityMonitor  string
+	SubMetrics            string
+	SubNBD                string
+	SubWaitingCache       string
+	SubCopyOnWrite        string
+	TickMigrator          time.Duration
+	TickSyncer            time.Duration
+	TickProtocol          time.Duration
+	TickToProtocol        time.Duration
+	TickFromProtocol      time.Duration
+	TickS3                time.Duration
+	TickDirtyTracker      time.Duration
+	TickVolatilityMonitor time.Duration
+	TickMetrics           time.Duration
+	TickNBD               time.Duration
+	TickWaitingCache      time.Duration
+	TickCopyOnWrite       time.Duration
 }
 
-func NewMetrics() *Metrics {
+func DefaultConfig() *MetricsConfig {
+	return &MetricsConfig{
+		HeatmapResolution:     64,
+		Namespace:             "silo",
+		SubSyncer:             "syncer",
+		SubMigrator:           "migrator",
+		SubProtocol:           "protocol",
+		SubToProtocol:         "toProtocol",
+		SubFromProtocol:       "fromProtocol",
+		SubS3:                 "s3",
+		SubDirtyTracker:       "dirtyTracker",
+		SubVolatilityMonitor:  "volatilityMonitor",
+		SubMetrics:            "metrics",
+		SubNBD:                "nbd",
+		SubWaitingCache:       "waitingCache",
+		SubCopyOnWrite:        "cow",
+		TickMigrator:          100 * time.Millisecond,
+		TickSyncer:            100 * time.Millisecond,
+		TickProtocol:          100 * time.Millisecond,
+		TickToProtocol:        100 * time.Millisecond,
+		TickFromProtocol:      100 * time.Millisecond,
+		TickS3:                100 * time.Millisecond,
+		TickDirtyTracker:      100 * time.Millisecond,
+		TickVolatilityMonitor: 100 * time.Millisecond,
+		TickMetrics:           100 * time.Millisecond,
+		TickNBD:               100 * time.Millisecond,
+		TickWaitingCache:      100 * time.Millisecond,
+		TickCopyOnWrite:       100 * time.Millisecond,
+	}
+}
+
+type Metrics struct {
+	config    *MetricsConfig
+	client    *statsd.Client
+	lock      sync.Mutex
+	cancelfns map[string]map[string]context.CancelFunc
+}
+
+func NewMetrics(config *MetricsConfig) *Metrics {
 	client := statsd.NewClient("localhost:8125",
 		statsd.MaxPacketSize(1400),
 		statsd.MetricPrefix("silo."))
 
 	return &Metrics{
-		client: client,
+		config:    config,
+		client:    client,
+		cancelfns: make(map[string]map[string]context.CancelFunc),
 	}
 }
 
-func (m *Metrics) Shutdown() {}
+func (m *Metrics) remove(subsystem string, id string, name string) {
+	m.lock.Lock()
+	cancelfns, ok := m.cancelfns[id]
+	if ok {
+		cancelfn, ok := cancelfns[fmt.Sprintf("%s_%s", subsystem, name)]
+		if ok {
+			cancelfn()
+			delete(cancelfns, fmt.Sprintf("%s_%s", subsystem, name))
+			if len(cancelfns) == 0 {
+				delete(m.cancelfns, id)
+			}
+		}
+	}
+	m.lock.Unlock()
+}
 
-func (m *Metrics) RemoveAllID(id string) {}
+func (m *Metrics) add(subsystem string, id string, name string, interval time.Duration, tickfn func()) {
+	m.lock.Lock()
+	cancelfns, ok := m.cancelfns[id]
+	if !ok {
+		cancelfns = make(map[string]context.CancelFunc)
+		m.cancelfns[id] = cancelfns
+	}
+	_, existing := cancelfns[fmt.Sprintf("%s_%s", subsystem, name)]
+	if existing {
+		// The metric is already being tracked.
+		m.lock.Unlock()
+		return
+	}
+
+	ctx, cancelfn := context.WithCancel(context.TODO())
+	cancelfns[fmt.Sprintf("%s_%s", subsystem, name)] = cancelfn
+
+	m.lock.Unlock()
+
+	ticker := time.NewTicker(interval)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				tickfn()
+			}
+		}
+	}()
+}
+
+func (m *Metrics) Shutdown() {
+	m.lock.Lock()
+	for _, cancelfns := range m.cancelfns {
+		for _, cancelfn := range cancelfns {
+			cancelfn()
+		}
+	}
+	m.cancelfns = make(map[string]map[string]context.CancelFunc)
+	m.lock.Unlock()
+}
+
+func (m *Metrics) RemoveAllID(id string) {
+	m.lock.Lock()
+	cancelfns, ok := m.cancelfns[id]
+	if ok {
+		for _, cancelfn := range cancelfns {
+			cancelfn()
+		}
+		delete(m.cancelfns, id)
+	}
+	m.lock.Unlock()
+}
 
 func (m *Metrics) AddSyncer(id string, name string, sync *migrator.Syncer) {}
-func (m *Metrics) RemoveSyncer(id string, name string)                     {}
+func (m *Metrics) RemoveSyncer(id string, name string) {
+	m.remove(m.config.SubSyncer, id, name)
+}
 
 func (m *Metrics) AddMigrator(id string, name string, mig *migrator.Migrator) {}
-func (m *Metrics) RemoveMigrator(id string, name string)                      {}
+func (m *Metrics) RemoveMigrator(id string, name string) {
+	m.remove(m.config.SubMigrator, id, name)
+}
 
 func (m *Metrics) AddProtocol(id string, name string, proto *protocol.RW) {}
-func (m *Metrics) RemoveProtocol(id string, name string)                  {}
+func (m *Metrics) RemoveProtocol(id string, name string) {
+	m.remove(m.config.SubProtocol, id, name)
+}
 
 func (m *Metrics) AddToProtocol(id string, name string, proto *protocol.ToProtocol) {}
-func (m *Metrics) RemoveToProtocol(id string, name string)                          {}
+func (m *Metrics) RemoveToProtocol(id string, name string) {
+	m.remove(m.config.SubToProtocol, id, name)
+}
 
 func (m *Metrics) AddFromProtocol(id string, name string, proto *protocol.FromProtocol) {}
-func (m *Metrics) RemoveFromProtocol(id string, name string)                            {}
+func (m *Metrics) RemoveFromProtocol(id string, name string) {
+	m.remove(m.config.SubFromProtocol, id, name)
+}
 
 func (m *Metrics) AddS3Storage(id string, name string, s3 *sources.S3Storage) {}
-func (m *Metrics) RemoveS3Storage(id string, name string)                     {}
+func (m *Metrics) RemoveS3Storage(id string, name string) {
+	m.remove(m.config.SubS3, id, name)
+}
 
 func (m *Metrics) AddDirtyTracker(id string, name string, dt *dirtytracker.Remote) {}
-func (m *Metrics) RemoveDirtyTracker(id string, name string)                       {}
+func (m *Metrics) RemoveDirtyTracker(id string, name string) {
+	m.remove(m.config.SubDirtyTracker, id, name)
+}
 
 func (m *Metrics) AddVolatilityMonitor(id string, name string, vm *volatilitymonitor.VolatilityMonitor) {
 }
-func (m *Metrics) RemoveVolatilityMonitor(id string, name string) {}
+func (m *Metrics) RemoveVolatilityMonitor(id string, name string) {
+	m.remove(m.config.SubVolatilityMonitor, id, name)
+}
 
 func (m *Metrics) AddMetrics(id string, name string, mm *modules.Metrics) {}
-func (m *Metrics) RemoveMetrics(id string, name string)                   {}
+func (m *Metrics) RemoveMetrics(id string, name string) {
+	m.remove(m.config.SubMetrics, id, name)
+}
 
 func (m *Metrics) AddNBD(id string, name string, mm *expose.ExposedStorageNBDNL) {}
-func (m *Metrics) RemoveNBD(id string, name string)                              {}
+func (m *Metrics) RemoveNBD(id string, name string) {
+	m.remove(m.config.SubNBD, id, name)
+}
 
 func (m *Metrics) AddWaitingCache(id string, name string, wc *waitingcache.Remote) {}
-func (m *Metrics) RemoveWaitingCache(id string, name string)                       {}
+func (m *Metrics) RemoveWaitingCache(id string, name string) {
+	m.remove(m.config.SubWaitingCache, id, name)
+}
 
 func (m *Metrics) AddCopyOnWrite(id string, name string, cow *modules.CopyOnWrite) {}
-func (m *Metrics) RemoveCopyOnWrite(id string, name string)                        {}
+func (m *Metrics) RemoveCopyOnWrite(id string, name string) {
+	m.remove(m.config.SubCopyOnWrite, id, name)
+}

--- a/telemetry/docker-compose.yaml
+++ b/telemetry/docker-compose.yaml
@@ -30,3 +30,15 @@ services:
     volumes:
       - ./grafana/provisioning:/etc/grafana/provisioning
     network_mode: host
+
+  vector:
+    image: timberio/vector:0.46.0-debian
+    expose:
+      - 2114
+      - 9800
+    ports:
+      - "2114:2114"
+      - "9800:9800"
+    volumes:
+      - ./vector/vector.yaml:/etc/vector/vector.yaml
+    network_mode: host

--- a/telemetry/prometheus/prometheus.yaml
+++ b/telemetry/prometheus/prometheus.yaml
@@ -31,3 +31,7 @@ scrape_configs:
   - job_name: "silo"
     static_configs:
       - targets: ["localhost:2112", "localhost:2113"]
+
+  - job_name: "vector"
+    static_configs:
+      - targets: ["localhost:2114"]

--- a/telemetry/vector/vector.yaml
+++ b/telemetry/vector/vector.yaml
@@ -1,0 +1,35 @@
+#                                    __   __  __
+#                                    \ \ / / / /
+#                                     \ V / / /
+#                                      \_/  \/
+#
+#                                    V E C T O R
+#                                   Configuration
+#
+# ------------------------------------------------------------------------------
+# Website: https://vector.dev
+# Docs: https://vector.dev/docs
+# Chat: https://chat.vector.dev
+# ------------------------------------------------------------------------------
+
+# Change this to use a non-default directory for Vector data storage:
+# data_dir: "/var/lib/vector"
+
+# Random Syslog-formatted logs
+sources:
+  silo_metrics:
+    type: "statsd"
+    address: "0.0.0.0:9800"
+    mode: udp
+
+sinks:
+  print:
+    type: "console"
+    inputs: ["silo_metrics"]
+    encoding:
+      codec: "text"
+      metric_tag_values: "full"
+  prom:
+    type: "prometheus_exporter"
+    inputs: ["silo_metrics"]
+    address: "0.0.0.0:2114"


### PR DESCRIPTION
This PR adds the option to export stats via statsd.
The internal architecture of metrics in Silo is pull based - we ask components to snapshot their metrics.
The statsd module then sends any changes to the destination.