### PR TITLE
Bugfix in write_combinator when used concurrently

### DIFF
--- a/pkg/storage/dirtytracker/dirty_tracker_test.go
+++ b/pkg/storage/dirtytracker/dirty_tracker_test.go
@@ -95,13 +95,13 @@ func TestReadDirtyTrackerMaxAge(t *testing.T) {
 	trackerRemote := setupDirty(t)
 
 	// Check the dirty blocks
-	blocks := trackerRemote.GetDirtyBlocks(10*time.Millisecond, 100, 1, 1000)
+	blocks := trackerRemote.GetDirtyBlocks(100*time.Millisecond, 100, 1, 1000)
 	assert.Equal(t, 0, len(blocks))
 
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	// Things should expire now...
-	blocks = trackerRemote.GetDirtyBlocks(10*time.Millisecond, 100, 1, 1000)
+	blocks = trackerRemote.GetDirtyBlocks(100*time.Millisecond, 100, 1, 1000)
 	slices.Sort(blocks)
 	expectedBlocks := []uint{0, 1, 2, 4, 5}
 	assert.Equal(t, expectedBlocks, blocks)

--- a/pkg/storage/modules/write_combinator_test.go
+++ b/pkg/storage/modules/write_combinator_test.go
@@ -1,6 +1,9 @@
 package modules
 
 import (
+	"fmt"
+	"math/rand"
+	"sync"
 	"testing"
 
 	"github.com/loopholelabs/silo/pkg/storage/sources"
@@ -44,4 +47,65 @@ func TestWriteCombinatorBasic(t *testing.T) {
 	met := combinator.GetMetrics()
 	assert.Equal(t, map[int]uint64{1: 1, 2: 2}, met.WritesAllowed)
 	assert.Equal(t, map[int]uint64{1: 1, 2: 0}, met.WritesBlocked)
+}
+
+func TestWriteCombinatorConcurrent(t *testing.T) {
+	blockSize := 1024
+	numBlocks := 64 * 1024
+
+	storage := sources.NewMemoryStorage(blockSize * numBlocks)
+
+	combinator := NewWriteCombinator(storage, blockSize)
+
+	// Try doing a couple of writes and make sure they're dealt with correctly...
+	source1 := combinator.AddSource(1)
+	source2 := combinator.AddSource(2)
+
+	// Make a couple of buffers with 1s and 2s in them so we can tell the data apart...
+	buffer1 := make([]byte, blockSize)
+	buffer2 := make([]byte, blockSize)
+	for i := 0; i < blockSize; i++ {
+		buffer1[i] = 1
+		buffer2[i] = 2
+	}
+
+	var wg sync.WaitGroup
+
+	// Randomly write to the blocks in both goroutines.
+	// Hopefully there will be some collisions.
+	wg.Add(1)
+	go func() {
+		order1 := rand.Perm(numBlocks)
+		for _, b := range order1 {
+			_, err := source1.WriteAt(buffer1, int64(b*blockSize))
+			assert.NoError(t, err)
+		}
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		order2 := rand.Perm(numBlocks)
+		for _, b := range order2 {
+			_, err := source2.WriteAt(buffer2, int64(b*blockSize))
+			assert.NoError(t, err)
+		}
+		wg.Done()
+	}()
+
+	// Wait for them...
+	wg.Wait()
+
+	// Now check... source2 should have won in all cases as it has higher priority...
+	checkBuffer := make([]byte, storage.Size())
+	storage.ReadAt(checkBuffer, 0)
+	for i := 0; i < len(checkBuffer); i++ {
+		assert.Equal(t, uint8(2), checkBuffer[i])
+	}
+
+	met := combinator.GetMetrics()
+	fmt.Printf("Allowed %v Blocked %v Dupe %v", met.WritesAllowed, met.WritesBlocked, met.WritesDuplicate)
+
+	// assert.Equal(t, map[int]uint64{1: 1, 2: 2}, met.WritesAllowed)
+	// assert.Equal(t, map[int]uint64{1: 1, 2: 0}, met.WritesBlocked)
 }

--- a/pkg/storage/modules/write_combinator_test.go
+++ b/pkg/storage/modules/write_combinator_test.go
@@ -1,7 +1,6 @@
 package modules
 
 import (
-	"fmt"
 	"math/rand"
 	"sync"
 	"testing"
@@ -104,8 +103,7 @@ func TestWriteCombinatorConcurrent(t *testing.T) {
 	}
 
 	met := combinator.GetMetrics()
-	fmt.Printf("Allowed %v Blocked %v Dupe %v", met.WritesAllowed, met.WritesBlocked, met.WritesDuplicate)
 
-	// assert.Equal(t, map[int]uint64{1: 1, 2: 2}, met.WritesAllowed)
-	// assert.Equal(t, map[int]uint64{1: 1, 2: 0}, met.WritesBlocked)
+	assert.Equal(t, uint64(numBlocks), met.WritesAllowed[2]) // All of the writes from P2P should be allowed
+	assert.Equal(t, uint64(0), met.WritesBlocked[2])         // None should be blocked
 }


### PR DESCRIPTION
When using S3 assist, data can arrive via P2P, and via S3 at the same time.
This data is combined using the write_combinator, which is configured to give priority to P2P.
However, there is no locking in place, which can cause the priority mechanism to fail, and so give priority to the S3 data instead of P2P.

This bugfix introduces block level locking, which fixes the issue. There is also a unit test which fails on the old code and passes on the new.